### PR TITLE
feat: use write-only passwords for mysql_database resources

### DIFF
--- a/docs/resources/mysql_database.md
+++ b/docs/resources/mysql_database.md
@@ -63,7 +63,12 @@ Required:
 
 - `access_level` (String) Access level for the database user, e.g. `full` or `readonly`
 - `external_access` (Boolean) Whether the database user should be accessible from outside the cluster
-- `password` (String, Sensitive) Password for the database user
+
+Optional:
+
+- `password` (String, Sensitive, Deprecated) Password for the database user
+- `password_wo` (String, Sensitive, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) Password for the database user; this field is mutually exclusive with `password` and will be used instead of it. The password is not stored in the database, but only used to create the user.
+- `password_wo_version` (Number) Version of the password for the database user; this is required when using `password_wo`.
 
 Read-Only:
 

--- a/internal/provider/resource/mysqldatabaseresource/model.go
+++ b/internal/provider/resource/mysqldatabaseresource/model.go
@@ -16,11 +16,13 @@ type ResourceModel struct {
 }
 
 type MySQLDatabaseUserModel struct {
-	ID             types.String `tfsdk:"id"`
-	Name           types.String `tfsdk:"name"`
-	Password       types.String `tfsdk:"password"`
-	AccessLevel    types.String `tfsdk:"access_level"`
-	ExternalAccess types.Bool   `tfsdk:"external_access"`
+	ID                types.String `tfsdk:"id"`
+	Name              types.String `tfsdk:"name"`
+	Password          types.String `tfsdk:"password"`
+	PasswordWO        types.String `tfsdk:"password_wo"`
+	PasswordWOVersion types.Int64  `tfsdk:"password_wo_version"`
+	AccessLevel       types.String `tfsdk:"access_level"`
+	ExternalAccess    types.Bool   `tfsdk:"external_access"`
 }
 
 type MySQLDatabaseCharsetModel struct {

--- a/internal/provider/resource/mysqldatabaseresource/model_api.go
+++ b/internal/provider/resource/mysqldatabaseresource/model_api.go
@@ -16,6 +16,11 @@ func (m *ResourceModel) ToCreateRequest(ctx context.Context, d diag.Diagnostics)
 	d.Append(m.CharacterSettings.As(ctx, &dataCharset, basetypes.ObjectAsOptions{})...)
 	d.Append(m.User.As(ctx, &dataUser, basetypes.ObjectAsOptions{})...)
 
+	password := dataUser.Password.ValueString()
+	if !dataUser.PasswordWO.IsNull() {
+		password = dataUser.PasswordWO.ValueString()
+	}
+
 	return databaseclientv2.CreateMysqlDatabaseRequest{
 		ProjectID: m.ProjectID.ValueString(),
 		Body: databaseclientv2.CreateMysqlDatabaseRequestBody{
@@ -28,7 +33,7 @@ func (m *ResourceModel) ToCreateRequest(ctx context.Context, d diag.Diagnostics)
 				},
 			},
 			User: databasev2.CreateMySqlUserWithDatabase{
-				Password:    dataUser.Password.ValueString(),
+				Password:    password,
 				AccessLevel: databasev2.CreateMySqlUserWithDatabaseAccessLevel(dataUser.AccessLevel.ValueString()),
 			},
 		},

--- a/internal/provider/resource/mysqldatabaseresource/resource.go
+++ b/internal/provider/resource/mysqldatabaseresource/resource.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
@@ -82,6 +83,9 @@ func (d *Resource) Schema(_ context.Context, _ resource.SchemaRequest, response 
 			},
 			"user": schema.SingleNestedAttribute{
 				Required: true,
+				Validators: []validator.Object{
+					&mysqlPasswordValidator{},
+				},
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed:            true,
@@ -98,9 +102,20 @@ func (d *Resource) Schema(_ context.Context, _ resource.SchemaRequest, response 
 						},
 					},
 					"password": schema.StringAttribute{
-						Required:            true,
+						Optional:            true,
 						Sensitive:           true,
 						MarkdownDescription: "Password for the database user",
+						DeprecationMessage:  "This attribute is deprecated and will be removed in a future version. Use `password_wo` instead.",
+					},
+					"password_wo": schema.StringAttribute{
+						Optional:            true,
+						Sensitive:           true,
+						MarkdownDescription: "Password for the database user; this field is mutually exclusive with `password` and will be used instead of it. The password is not stored in the database, but only used to create the user.",
+						WriteOnly:           true,
+					},
+					"password_wo_version": schema.Int64Attribute{
+						Optional:            true,
+						MarkdownDescription: "Version of the password for the database user; this is required when using `password_wo`.",
 					},
 					"access_level": schema.StringAttribute{
 						Required:            true,
@@ -221,43 +236,76 @@ func (d *Resource) findDatabaseUser(ctx context.Context, databaseID string, data
 }
 
 func (d *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	var planData, stateData ResourceModel
-
-	client := d.client.Database()
-
-	dataUser := MySQLDatabaseUserModel{}
-	dataCharset := MySQLDatabaseCharsetModel{}
-
-	resp.Diagnostics.Append(req.Plan.Get(ctx, &planData)...)
-	resp.Diagnostics.Append(req.State.Get(ctx, &stateData)...)
-	resp.Diagnostics.Append(planData.User.As(ctx, &dataUser, basetypes.ObjectAsOptions{})...)
-	resp.Diagnostics.Append(planData.CharacterSettings.As(ctx, &dataCharset, basetypes.ObjectAsOptions{})...)
+	planData, planUser, _ := d.unpack(ctx, req.Plan, &resp.Diagnostics)
+	stateData, stateUser, _ := d.unpack(ctx, req.Plan, &resp.Diagnostics)
 
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	if !planData.Description.Equal(stateData.Description) {
-		providerutil.
-			Try[any](&resp.Diagnostics, "error while updating database").
-			DoResp(client.UpdateMysqlDatabaseDescription(ctx, databaseclientv2.UpdateMysqlDatabaseDescriptionRequest{
-				MysqlDatabaseID: planData.ID.ValueString(),
-				Body: databaseclientv2.UpdateMysqlDatabaseDescriptionRequestBody{
-					Description: planData.Description.ValueString(),
-				},
-			}))
+	// TODO: Update charsets
+	d.updateDescription(ctx, &planData, &stateData, resp)
+	d.updatePasswordDeprecated(ctx, &planUser, resp)
+	d.updatePassword(ctx, &planUser, &stateUser, resp)
+}
+
+func (d *Resource) unpack(ctx context.Context, planOrState interface {
+	Get(context.Context, any) diag.Diagnostics
+}, diags *diag.Diagnostics) (data ResourceModel, user MySQLDatabaseUserModel, charset MySQLDatabaseCharsetModel) {
+	diags.Append(planOrState.Get(ctx, &data)...)
+	diags.Append(data.User.As(ctx, &user, basetypes.ObjectAsOptions{})...)
+	diags.Append(data.CharacterSettings.As(ctx, &charset, basetypes.ObjectAsOptions{})...)
+
+	return
+}
+
+func (d *Resource) updateDescription(ctx context.Context, planData, stateData *ResourceModel, resp *resource.UpdateResponse) {
+	if planData.Description.Equal(stateData.Description) {
+		return
 	}
+
+	client := d.client.Database()
+
+	providerutil.
+		Try[any](&resp.Diagnostics, "error while updating database").
+		DoResp(client.UpdateMysqlDatabaseDescription(ctx, databaseclientv2.UpdateMysqlDatabaseDescriptionRequest{
+			MysqlDatabaseID: planData.ID.ValueString(),
+			Body: databaseclientv2.UpdateMysqlDatabaseDescriptionRequestBody{
+				Description: planData.Description.ValueString(),
+			},
+		}))
+}
+
+func (d *Resource) updatePassword(ctx context.Context, planUser, stateUser *MySQLDatabaseUserModel, resp *resource.UpdateResponse) {
+	hasWriteOnlyPassword := !planUser.PasswordWO.IsNull()
+	isChanged := !planUser.PasswordWOVersion.Equal(stateUser.PasswordWOVersion)
+
+	if !hasWriteOnlyPassword || !isChanged {
+		return
+	}
+
+	d.updatePasswordInternal(ctx, planUser, planUser.PasswordWO.ValueString(), resp)
+}
+
+func (d *Resource) updatePasswordDeprecated(ctx context.Context, planUser *MySQLDatabaseUserModel, resp *resource.UpdateResponse) {
+	if planUser.Password.IsNull() {
+		return
+	}
+
+	d.updatePasswordInternal(ctx, planUser, planUser.Password.ValueString(), resp)
+}
+
+func (d *Resource) updatePasswordInternal(ctx context.Context, planUser *MySQLDatabaseUserModel, password string, resp *resource.UpdateResponse) {
+	client := d.client.Database()
 
 	providerutil.
 		Try[any](&resp.Diagnostics, "error while setting database user password").
 		DoResp(client.UpdateMysqlUserPassword(ctx, databaseclientv2.UpdateMysqlUserPasswordRequest{
-			MysqlUserID: dataUser.ID.ValueString(),
+			MysqlUserID: planUser.ID.ValueString(),
 			Body: databaseclientv2.UpdateMysqlUserPasswordRequestBody{
-				Password: dataUser.Password.ValueString(),
+				Password: password,
 			},
 		}))
-
-	resp.Diagnostics.Append(resp.State.Set(ctx, &planData)...)
 }
 
 func (d *Resource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {

--- a/internal/provider/resource/mysqldatabaseresource/validator_password.go
+++ b/internal/provider/resource/mysqldatabaseresource/validator_password.go
@@ -1,0 +1,35 @@
+package mysqldatabaseresource
+
+import (
+	"context"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+)
+
+type mysqlPasswordValidator struct {
+}
+
+func (m *mysqlPasswordValidator) Description(_ context.Context) string {
+	return "Asserts that the password is not set when using password_wo and that password_wo_version is set when using password_wo."
+}
+
+func (m *mysqlPasswordValidator) MarkdownDescription(_ context.Context) string {
+	return "Asserts that the password is not set when using password_wo and that password_wo_version is set when using password_wo."
+}
+
+func (m *mysqlPasswordValidator) ValidateObject(_ context.Context, request validator.ObjectRequest, response *validator.ObjectResponse) {
+	password, hasPassword := request.ConfigValue.Attributes()["password"]
+	writeOnlyPassword, hasWriteOnlyPassword := request.ConfigValue.Attributes()["password_wo"]
+	passwordVersion, hasPasswordVersion := request.ConfigValue.Attributes()["password_wo_version"]
+
+	if hasPassword && !password.IsNull() && hasWriteOnlyPassword && !writeOnlyPassword.IsNull() {
+		response.Diagnostics.AddAttributeWarning(
+			request.Path.AtName("password_wo"), "duplicate password", "password and password_wo are mutually exclusive; will prefer password_wo",
+		)
+	}
+
+	if hasWriteOnlyPassword && !writeOnlyPassword.IsNull() && (!hasPasswordVersion || passwordVersion.IsNull()) {
+		response.Diagnostics.AddAttributeError(
+			request.Path.AtName("password_wo_version"), "missing password_wo_version", "password_wo_version is required when using password_wo",
+		)
+	}
+}


### PR DESCRIPTION
This commit changes the `mittwald_mysql_database` resource to (preferably)
accept passwords as write-only attributes.

The regular `password` attribute is still there, but declared as deprecated.
It will also trigger a warning when both `password` and `password_wo` are set.
