### PR TITLE
Correctly get values for write-only mysql_database passwords

### DIFF
--- a/docs/resources/mysql_database.md
+++ b/docs/resources/mysql_database.md
@@ -67,7 +67,7 @@ Required:
 Optional:
 
 - `password` (String, Sensitive, Deprecated) Password for the database user
-- `password_wo` (String, Sensitive, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) Password for the database user; this field is mutually exclusive with `password` and will be used instead of it. The password is not stored in the database, but only used to create the user.
+- `password_wo` (String, Sensitive, [Write-only](https://developer.hashicorp.com/terraform/language/resources/ephemeral#write-only-arguments)) Password for the database user; this field is mutually exclusive with `password` and will be used instead of it. The password is not stored in the database, but only used to create the user. You can use the `mittwald_mysql_password` ephemeral resource to dynamically generate a valid password.
 - `password_wo_version` (Number) Version of the password for the database user; this is required when using `password_wo`.
 
 Read-Only:

--- a/internal/provider/resource/mysqldatabaseresource/model_api.go
+++ b/internal/provider/resource/mysqldatabaseresource/model_api.go
@@ -9,16 +9,16 @@ import (
 	"github.com/mittwald/api-client-go/mittwaldv2/generated/schemas/databasev2"
 )
 
-func (m *ResourceModel) ToCreateRequest(ctx context.Context, d diag.Diagnostics) databaseclientv2.CreateMysqlDatabaseRequest {
+func (m *ResourceModel) ToCreateRequest(ctx context.Context, d diag.Diagnostics, password types.String) databaseclientv2.CreateMysqlDatabaseRequest {
 	dataCharset := MySQLDatabaseCharsetModel{}
 	dataUser := MySQLDatabaseUserModel{}
 
 	d.Append(m.CharacterSettings.As(ctx, &dataCharset, basetypes.ObjectAsOptions{})...)
 	d.Append(m.User.As(ctx, &dataUser, basetypes.ObjectAsOptions{})...)
 
-	password := dataUser.Password.ValueString()
-	if !dataUser.PasswordWO.IsNull() {
-		password = dataUser.PasswordWO.ValueString()
+	actualPassword := dataUser.Password.ValueString()
+	if !password.IsNull() {
+		actualPassword = password.ValueString()
 	}
 
 	return databaseclientv2.CreateMysqlDatabaseRequest{
@@ -33,7 +33,7 @@ func (m *ResourceModel) ToCreateRequest(ctx context.Context, d diag.Diagnostics)
 				},
 			},
 			User: databasev2.CreateMySqlUserWithDatabase{
-				Password:    password,
+				Password:    actualPassword,
 				AccessLevel: databasev2.CreateMySqlUserWithDatabaseAccessLevel(dataUser.AccessLevel.ValueString()),
 			},
 		},

--- a/internal/provider/resource/mysqldatabaseresource/resource.go
+++ b/internal/provider/resource/mysqldatabaseresource/resource.go
@@ -108,10 +108,13 @@ func (d *Resource) Schema(_ context.Context, _ resource.SchemaRequest, response 
 						DeprecationMessage:  "This attribute is deprecated and will be removed in a future version. Use `password_wo` instead.",
 					},
 					"password_wo": schema.StringAttribute{
-						Optional:            true,
-						Sensitive:           true,
-						MarkdownDescription: "Password for the database user; this field is mutually exclusive with `password` and will be used instead of it. The password is not stored in the database, but only used to create the user.",
-						WriteOnly:           true,
+						Optional:  true,
+						Sensitive: true,
+						MarkdownDescription: "Password for the database user; this field is mutually exclusive with " +
+							"`password` and will be used instead of it. The password is not stored in the database, " +
+							"but only used to create the user. You can use the `mittwald_mysql_password` ephemeral " +
+							"resource to dynamically generate a valid password.",
+						WriteOnly: true,
 					},
 					"password_wo_version": schema.Int64Attribute{
 						Optional:            true,


### PR DESCRIPTION
- **fix: get mysql password_wo directly from config, not from plan**
- **docs: mention mysql_password ephemeral resource in docs**
- **chore: add acceptance test for generated mysql passwords**
