### PR TITLE
Drop warning about alpha release

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,6 @@ This repository contains a [Terraform](https://www.terraform.io) provider for re
 
 ## Installation
 
-> [!IMPORTANT]
-> This provider is an alpha state; we do not fully recommend using it in production environments, as it is not yet feature-complete and may contain bugs. However, we are happy to receive feedback and contributions!
-
 You can install this provider from the [Terraform registry](https://registry.terraform.io/providers/mittwald/mittwald/latest). For this, add the following code to your Terraform configuration:
 
 ```hcl


### PR DESCRIPTION
This provider has been out of alpha for quite a while now. For this reason, the stability warning in the README should also be dropped
