### PR TITLE
docs: add container example to virtualhost resource

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,10 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(go generate:*)",
+      "Bash(git add:*)"
+    ],
+    "deny": [],
+    "ask": []
+  }
+}

--- a/docs/resources/virtualhost.md
+++ b/docs/resources/virtualhost.md
@@ -36,6 +36,10 @@ resource "mittwald_virtualhost" "foobar" {
     "/redirect" = {
       redirect = "https://redirect.example"
     }
+
+    "/default" = {
+      // keep empty to redirect to empty default page
+    }
   }
 }
 ```

--- a/docs/resources/virtualhost.md
+++ b/docs/resources/virtualhost.md
@@ -26,6 +26,13 @@ resource "mittwald_virtualhost" "foobar" {
       app = mittwald_app.foobar.id
     }
 
+    "/api" = {
+      container = {
+        container_id = mittwald_container_stack.foobar.containers.api.id
+        port         = "3000/tcp"
+      }
+    }
+
     "/redirect" = {
       redirect = "https://redirect.example"
     }

--- a/examples/resources/mittwald_virtualhost/resource.tf
+++ b/examples/resources/mittwald_virtualhost/resource.tf
@@ -21,5 +21,9 @@ resource "mittwald_virtualhost" "foobar" {
     "/redirect" = {
       redirect = "https://redirect.example"
     }
+
+    "/default" = {
+      // keep empty to redirect to empty default page
+    }
   }
 }

--- a/examples/resources/mittwald_virtualhost/resource.tf
+++ b/examples/resources/mittwald_virtualhost/resource.tf
@@ -11,6 +11,13 @@ resource "mittwald_virtualhost" "foobar" {
       app = mittwald_app.foobar.id
     }
 
+    "/api" = {
+      container = {
+        container_id = mittwald_container_stack.foobar.containers.api.id
+        port         = "3000/tcp"
+      }
+    }
+
     "/redirect" = {
       redirect = "https://redirect.example"
     }


### PR DESCRIPTION
## Summary

- Adds container connection example to `mittwald_virtualhost` resource documentation
- Shows how to connect container stack containers to virtualhost paths
- Demonstrates required `container_id` and `port` configuration

🤖 Generated with [Claude Code](https://claude.ai/code)