### PR TITLE
validation failed with ['pagination.limit: Must be less than or equal to 1000']

### DIFF
--- a/internal/apiext/app_client_systemsoftware.go
+++ b/internal/apiext/app_client_systemsoftware.go
@@ -3,12 +3,13 @@ package apiext
 import (
 	"context"
 	"fmt"
+	"sort"
+	"strings"
+
 	"github.com/Masterminds/semver/v3"
 	"github.com/mittwald/api-client-go/mittwaldv2/generated/clients/appclientv2"
 	"github.com/mittwald/api-client-go/mittwaldv2/generated/schemas/appv2"
 	"github.com/mittwald/api-client-go/pkg/util/pointer"
-	"sort"
-	"strings"
 )
 
 type SystemSoftwareVersionSet []appv2.SystemSoftwareVersion
@@ -39,7 +40,7 @@ func (s SystemSoftwareVersionSet) Recommended() (*appv2.SystemSoftwareVersion, b
 }
 
 func (c *appClient) GetSystemsoftwareByName(ctx context.Context, name string) (*appv2.SystemSoftware, bool, error) {
-	systemSoftwaresReq := appclientv2.ListSystemsoftwaresRequest{Limit: pointer.To[int64](9999)}
+	systemSoftwaresReq := appclientv2.ListSystemsoftwaresRequest{Limit: pointer.To[int64](999)}
 	systemSoftwares, _, err := c.ListSystemsoftwares(ctx, systemSoftwaresReq)
 	if err != nil {
 		return nil, false, err


### PR DESCRIPTION
The following error occurs when using the `mittwald_systemsoftware` data provider:
```
invalid request: 3 INVALID_ARGUMENT: validation failed with ['pagination.limit: Must be less than or equal to 1000']
```