### PR TITLE
fix(container_stack): description attr is actually required by API

### DIFF
--- a/docs/resources/container_stack.md
+++ b/docs/resources/container_stack.md
@@ -112,14 +112,14 @@ Required:
 
 - `command` (List of String) The command to run inside the container.
 
-Note that this is a required value, even if the image already has a default command. To use the default command, use the `mittwald_container_image` data source to first determine the default command, and then use that value here.
+    Note that this is a required value, even if the image already has a default command. To use the default command, use the `mittwald_container_image` data source to first determine the default command, and then use that value here.
 - `description` (String) A description for the container.
 - `entrypoint` (List of String) The entrypoint to use for the container.
 
-Note that this is a required value, even if the image already has a default entrypoint. To use the default entrypoint, use the `mittwald_container_image` data source to first determine the default entrypoint, and then use that value here.
+    Note that this is a required value, even if the image already has a default entrypoint. To use the default entrypoint, use the `mittwald_container_image` data source to first determine the default entrypoint, and then use that value here.
 - `image` (String) The image to use for the container. Follows the usual Docker image format, e.g. `nginx:latest` or `registry.example.com/my-image:latest`.
 
-  Note that when using a non-standard registry (or a standard registry with credentials), you will probably also need to add a `mittwald_container_registry` resource somewhere in your plan.
+      Note that when using a non-standard registry (or a standard registry with credentials), you will probably also need to add a `mittwald_container_registry` resource somewhere in your plan.
 
 Optional:
 

--- a/internal/provider/resource/containerstack/resource.go
+++ b/internal/provider/resource/containerstack/resource.go
@@ -64,7 +64,7 @@ func (r *Resource) Schema(_ context.Context, _ resource.SchemaRequest, resp *res
 							Required: true,
 							MarkdownDescription: "The image to use for the container. Follows the usual Docker image format, " +
 								"e.g. `nginx:latest` or `registry.example.com/my-image:latest`.\n\n  " +
-								"Note that when using a non-standard registry (or a standard registry with credentials), " +
+								"    Note that when using a non-standard registry (or a standard registry with credentials), " +
 								"you will probably also need to add a `mittwald_container_registry` resource somewhere " +
 								"in your plan.",
 							PlanModifiers: []planmodifier.String{
@@ -78,7 +78,7 @@ func (r *Resource) Schema(_ context.Context, _ resource.SchemaRequest, resp *res
 						"command": schema.ListAttribute{
 							Required: true,
 							MarkdownDescription: "The command to run inside the container.\n\n" +
-								"Note that this is a required value, even if the image already has a default command. " +
+								"    Note that this is a required value, even if the image already has a default command. " +
 								"To use the default command, use the `mittwald_container_image` data source to first " +
 								"determine the default command, and then use that value here.",
 							ElementType: types.StringType,
@@ -86,7 +86,7 @@ func (r *Resource) Schema(_ context.Context, _ resource.SchemaRequest, resp *res
 						"entrypoint": schema.ListAttribute{
 							Required: true,
 							MarkdownDescription: "The entrypoint to use for the container.\n\n" +
-								"Note that this is a required value, even if the image already has a default entrypoint. " +
+								"    Note that this is a required value, even if the image already has a default entrypoint. " +
 								"To use the default entrypoint, use the `mittwald_container_image` data source to first " +
 								"determine the default entrypoint, and then use that value here.",
 							ElementType: types.StringType,


### PR DESCRIPTION
Declare the `mittwald_container_stack.containers[*].description` field as required.

This is _technically_ a breaking change. However, the description field was _always_ a required field in the API, so this _never_ worked as it intended.

Fixes #288
