### PR TITLE
fix(containerstack): use plan volumes for disregardUnknown check

### DIFF
--- a/internal/provider/resource/containerstack/model_api_from.go
+++ b/internal/provider/resource/containerstack/model_api_from.go
@@ -63,7 +63,7 @@ func (m *ContainerStackModel) FromAPIModel(ctx context.Context, apiModel *contai
 	// Convert Volumes
 	volumeMap := make(map[string]attr.Value)
 	for _, volume := range apiModel.Volumes {
-		_, hasExisting := m.Volumes.Elements()[volume.Name]
+		_, hasExisting := plan.Volumes.Elements()[volume.Name]
 
 		if !hasExisting && m.DefaultStack.ValueBool() && disregardUnknown {
 			tflog.Debug(ctx, "disregarding unmanaged volume in default stack", map[string]any{"name": volume.Name})


### PR DESCRIPTION
Hi there,

I noticed some unexpected behaviour when working with named volumes on a default container stack. When adding new named volumes to an existing stack (e.g. by adding a new container that references them), `terraform apply` reports:

```
Error: Provider produced inconsistent result after apply

.volumes: element "my-volume" has vanished.
```

The volumes are actually created correctly on the platform side — the `GetStack` API response includes them. But the state does not pick them up, so Terraform thinks they disappeared.

After digging into the code, I think the issue might be in `model_api_from.go`. The volume filtering loop on line 66 checks `m.Volumes.Elements()` (the current/old state) to decide whether a volume is "known":

```go
_, hasExisting := m.Volumes.Elements()[volume.Name]
```

When the old state does not yet contain the new volume names, `hasExisting` is `false`, and with `disregardUnknown = true` on a default stack, the volumes get skipped.

The analogous check for containers on line 33 uses `plan.Containers.Elements()` instead, which seems intentional — it checks the desired configuration rather than the old state:

```go
_, hasExisting := plan.Containers.Elements()[service.ServiceName]
```

This PR aligns the volume check with the container check by using `plan.Volumes` instead of `m.Volumes`. In my testing this resolves the "vanished" error and produces a stable state with no drift on subsequent plans.

Happy to adjust anything if I am misreading the intent here — just wanted to flag the behaviour and share what worked for us.