### PR TITLE
fix(app): retry UpdateAppinstallation after create for permission propagation

### DIFF
--- a/internal/apiext/app_client.go
+++ b/internal/apiext/app_client.go
@@ -5,6 +5,8 @@ import (
 	mittwaldv2 "github.com/mittwald/api-client-go/mittwaldv2/generated/clients"
 	"github.com/mittwald/api-client-go/mittwaldv2/generated/clients/appclientv2"
 	"github.com/mittwald/api-client-go/mittwaldv2/generated/schemas/appv2"
+	"github.com/mittwald/terraform-provider-mittwald/internal/apiutils"
+	"time"
 )
 
 type AppClient interface {
@@ -13,6 +15,7 @@ type AppClient interface {
 	GetSystemsoftwareAndVersion(ctx context.Context, systemSoftwareID, systemSoftwareVersionID string) (*appv2.SystemSoftware, *appv2.SystemSoftwareVersion, error)
 	SelectSystemsoftwareVersion(ctx context.Context, systemSoftwareID, versionSelector string) (SystemSoftwareVersionSet, error)
 	UpdateAppinstallation(ctx context.Context, appInstallationID string, updater ...AppInstallationUpdater) error
+	UpdateAppinstallationWithRetry(ctx context.Context, appInstallationID string, updater ...AppInstallationUpdater) error
 	WaitUntilAppInstallationIsReady(ctx context.Context, appID string) error
 	GetAppByName(ctx context.Context, name string) (*appv2.App, bool, error)
 	SelectAppVersion(ctx context.Context, appID, versionSelector string) (AppVersionSet, error)
@@ -93,11 +96,7 @@ func RemoveAppInstallationSystemSoftware(systemSoftwareID string) AppInstallatio
 	})
 }
 
-func (c *appClient) UpdateAppinstallation(ctx context.Context, appInstallationID string, updater ...AppInstallationUpdater) error {
-	if len(updater) == 0 {
-		return nil
-	}
-
+func (c *appClient) buildPatchRequest(appInstallationID string, updater ...AppInstallationUpdater) appclientv2.PatchAppinstallationRequest {
 	req := appclientv2.PatchAppinstallationRequest{
 		AppInstallationID: appInstallationID,
 	}
@@ -106,6 +105,35 @@ func (c *appClient) UpdateAppinstallation(ctx context.Context, appInstallationID
 		u.Apply(&req.Body)
 	}
 
-	_, err := c.PatchAppinstallation(ctx, req)
+	return req
+}
+
+func (c *appClient) UpdateAppinstallation(ctx context.Context, appInstallationID string, updater ...AppInstallationUpdater) error {
+	if len(updater) == 0 {
+		return nil
+	}
+
+	_, err := c.PatchAppinstallation(ctx, c.buildPatchRequest(appInstallationID, updater...))
+	return err
+}
+
+// UpdateAppinstallationWithRetry wraps PatchAppinstallation with polling
+// to handle transient permission errors that occur when the API has not yet
+// propagated permissions for a newly created app installation.
+func (c *appClient) UpdateAppinstallationWithRetry(ctx context.Context, appInstallationID string, updater ...AppInstallationUpdater) error {
+	if len(updater) == 0 {
+		return nil
+	}
+
+	req := c.buildPatchRequest(appInstallationID, updater...)
+
+	_, err := apiutils.Poll(ctx, apiutils.PollOpts{
+		InitialDelay: 500 * time.Millisecond,
+		MaxDelay:     5 * time.Second,
+	}, func(ctx context.Context, r appclientv2.PatchAppinstallationRequest) (struct{}, error) {
+		_, err := c.PatchAppinstallation(ctx, r)
+		return struct{}{}, err
+	}, req)
+
 	return err
 }

--- a/internal/provider/resource/appresource/resource.go
+++ b/internal/provider/resource/appresource/resource.go
@@ -208,7 +208,7 @@ func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp 
 	data.ID = types.StringValue(installation.Id)
 
 	try := providerutil.Try[any](&resp.Diagnostics, "error while updating app installation")
-	try.Do(appClient.UpdateAppinstallation(ctx, installation.Id, appUpdaters...))
+	try.Do(appClient.UpdateAppinstallationWithRetry(ctx, installation.Id, appUpdaters...))
 
 	for _, database := range databases {
 		try.DoResp(appClient.LinkDatabase(

--- a/internal/provider/resource/projectresource/resource.go
+++ b/internal/provider/resource/projectresource/resource.go
@@ -126,7 +126,7 @@ func (r *Resource) Read(ctx context.Context, req resource.ReadRequest, resp *res
 		return
 	}
 
-	readCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
+	readCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
 	resp.Diagnostics.Append(r.read(readCtx, &data)...)
@@ -141,10 +141,22 @@ func (r *Resource) read(ctx context.Context, data *ResourceModel) (res diag.Diag
 		IgnoreNotFound().
 		DoVal(apiutils.PollRequest(ctx, apiutils.PollOpts{}, client.GetProject, projectclientv2.GetProjectRequest{ProjectID: data.ID.ValueString()}))
 
+	// Wrap GetProjectDefaultIPs to convert ErrNoDefaultIngress to ErrPollShouldRetry
+	// so that the Poll function will retry until the default ingress appears.
+	// This handles the case where Terraform refreshes a recently created project
+	// before the default ingress has been propagated by the API.
+	getIPsWithRetry := func(ctx context.Context, projectID string) ([]string, error) {
+		ips, err := client.GetProjectDefaultIPs(ctx, projectID)
+		if errors.Is(err, apiext.ErrNoDefaultIngress) {
+			return nil, apiutils.ErrPollShouldRetry
+		}
+		return ips, err
+	}
+
 	ips := providerutil.
 		Try[[]string](&res, "error while reading project ips").
 		IgnoreNotFound().
-		DoVal(client.GetProjectDefaultIPs(ctx, data.ID.ValueString()))
+		DoVal(apiutils.Poll(ctx, apiutils.PollOpts{}, getIPsWithRetry, data.ID.ValueString()))
 
 	if res.HasError() {
 		return


### PR DESCRIPTION
## Summary

Two related fixes for race conditions during parallel resource creation:

1. **fix(app):** `mittwald_app` creates fail with "permission to resource denied" when multiple apps are created in parallel (#363)
2. **fix(project):** `mittwald_project` Read path fails with "project does not have a default ingress" when refreshing recently created projects (incomplete fix for #339)

## Changes

### Fix 1: App permission retry (Fixes #363)

- Adds `UpdateAppinstallationWithRetry` that wraps `PatchAppinstallation` in `apiutils.Poll` to retry on transient `ErrPermissionDenied`
- Only the `Create` path uses the retry variant; `Update` remains unchanged
- Extracts `buildPatchRequest` helper to avoid duplicating request construction

### Fix 2: Project Read path retry (Relates to #339)

- Applies the same `ErrNoDefaultIngress → ErrPollShouldRetry` pattern from `readAfterCreate` to the regular `read()` path
- Increases `Read` timeout from 3s to 30s
- The v1.8.0 fix for #339 only covered the `Create` → `readAfterCreate` path; the regular `Read` path (used during refresh of dependent resources) was missed

## Test plan

- [x] `go build ./...` passes
- [x] Manual end-to-end test: full infrastructure bootstrap with 3 projects, 3 WordPress apps (parallel), 6 container stacks — all resources created in single apply without errors
- [ ] Existing acceptance tests pass

## Environment

- Terraform: 1.14.3
- Provider: built from v1.8.2 + this branch
- macOS / darwin_arm64

🤖 Generated with [Claude Code](https://claude.ai/claude-code)