### PR TITLE
fix(app): wait for installation readiness around create and update

### DIFF
--- a/internal/apiext/app_client.go
+++ b/internal/apiext/app_client.go
@@ -2,9 +2,15 @@ package apiext
 
 import (
 	"context"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	mittwaldv2 "github.com/mittwald/api-client-go/mittwaldv2/generated/clients"
 	"github.com/mittwald/api-client-go/mittwaldv2/generated/clients/appclientv2"
 	"github.com/mittwald/api-client-go/mittwaldv2/generated/schemas/appv2"
+	"github.com/mittwald/terraform-provider-mittwald/internal/apiutils"
 )
 
 type AppClient interface {
@@ -106,6 +112,63 @@ func (c *appClient) UpdateAppinstallation(ctx context.Context, appInstallationID
 		u.Apply(&req.Body)
 	}
 
-	_, err := c.PatchAppinstallation(ctx, req)
+	_, err := c.retryWhilePhaseNotReady(ctx, func(ctx context.Context) (*http.Response, error) {
+		return c.PatchAppinstallation(ctx, req)
+	})
 	return err
+}
+
+// LinkDatabase wraps the generated client call with a retry on the transient
+// "not in ready phase" error; see retryWhilePhaseNotReady.
+func (c *appClient) LinkDatabase(ctx context.Context, req appclientv2.LinkDatabaseRequest, reqEditors ...func(req *http.Request) error) (*http.Response, error) {
+	return c.retryWhilePhaseNotReady(ctx, func(ctx context.Context) (*http.Response, error) {
+		return c.Client.LinkDatabase(ctx, req, reqEditors...)
+	})
+}
+
+// UnlinkDatabase wraps the generated client call with a retry on the transient
+// "not in ready phase" error; see retryWhilePhaseNotReady.
+func (c *appClient) UnlinkDatabase(ctx context.Context, req appclientv2.UnlinkDatabaseRequest, reqEditors ...func(req *http.Request) error) (*http.Response, error) {
+	return c.retryWhilePhaseNotReady(ctx, func(ctx context.Context) (*http.Response, error) {
+		return c.Client.UnlinkDatabase(ctx, req, reqEditors...)
+	})
+}
+
+// isPhaseNotReadyError reports whether err indicates that the app installation
+// is currently in a phase that does not accept mutating requests. After an
+// installation first becomes ready, the backend briefly transitions through
+// additional phases (e.g. while deploying the project environment) and rejects
+// mutations during that window with an error such as:
+//
+//	VError: expected phase APP_PHASE_READY, current phase is APP_PHASE_DEPLOYING_PROJECT_ENVIRONMENT
+//
+// Those phases are not exposed through the REST "phase" enum and are transient,
+// so the request should simply be retried until the installation settles.
+func isPhaseNotReadyError(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "expected phase APP_PHASE_READY")
+}
+
+// retryWhilePhaseNotReady runs f, retrying for as long as the installation
+// rejects the request because it is not in the "ready" phase. The first attempt
+// runs immediately so the common (already-ready) case is not delayed.
+func (c *appClient) retryWhilePhaseNotReady(ctx context.Context, f func(context.Context) (*http.Response, error)) (*http.Response, error) {
+	resp, err := f(ctx)
+	if !isPhaseNotReadyError(err) {
+		return resp, err
+	}
+
+	tflog.Debug(ctx, "app installation is not in a mutable phase yet; retrying", map[string]any{"error": err.Error()})
+
+	o := apiutils.PollOpts{
+		InitialDelay: 2 * time.Second,
+		MaxDelay:     30 * time.Second,
+	}
+
+	return apiutils.Poll(ctx, o, func(ctx context.Context, _ struct{}) (*http.Response, error) {
+		resp, err := f(ctx)
+		if isPhaseNotReadyError(err) {
+			return nil, apiutils.ErrPollShouldRetry
+		}
+		return resp, err
+	}, struct{}{})
 }

--- a/internal/apiext/app_client_ready.go
+++ b/internal/apiext/app_client_ready.go
@@ -2,12 +2,20 @@ package apiext
 
 import (
 	"context"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/mittwald/api-client-go/mittwaldv2/generated/clients/appclientv2"
 	"github.com/mittwald/api-client-go/mittwaldv2/generated/schemas/appv2"
 	"github.com/mittwald/terraform-provider-mittwald/internal/apiutils"
 	"net/http"
 	"time"
 )
+
+func strOrNil(s *string) any {
+	if s == nil {
+		return nil
+	}
+	return *s
+}
 
 func (c *appClient) WaitUntilAppInstallationIsReady(ctx context.Context, appID string) error {
 	request := appclientv2.GetAppinstallationRequest{AppInstallationID: appID}
@@ -18,13 +26,59 @@ func (c *appClient) WaitUntilAppInstallationIsReady(ctx context.Context, appID s
 			return nil, nil, err
 		}
 
-		if inst.AppVersion.Current == nil {
+		notReady := func(reason string, extra map[string]any) (*appv2.AppInstallation, *http.Response, error) {
+			fields := map[string]any{
+				"app_installation_id": inst.Id,
+				"phase":               string(inst.Phase),
+				"reason":              reason,
+			}
+			for k, v := range extra {
+				fields[k] = v
+			}
+			tflog.Debug(ctx, "app installation not ready yet", fields)
 			return nil, nil, apiutils.ErrPollShouldRetry
 		}
 
-		if *inst.AppVersion.Current != inst.AppVersion.Desired {
-			return nil, nil, apiutils.ErrPollShouldRetry
+		// The API only accepts mutating requests (such as PATCH or linking a
+		// database) once the installation has finished provisioning and reached
+		// the "ready" phase. This also covers the "reconfiguring"/"upgrading"
+		// phases that an app or dependency update transitions through.
+		if inst.Phase != appv2.PhaseReady {
+			return notReady("phase is not ready", nil)
 		}
+
+		// Wait until the running app version has caught up with the desired one.
+		if inst.AppVersion.Current == nil || *inst.AppVersion.Current != inst.AppVersion.Desired {
+			return notReady("app version not converged", map[string]any{
+				"app_version_current": strOrNil(inst.AppVersion.Current),
+				"app_version_desired": inst.AppVersion.Desired,
+			})
+		}
+
+		// Wait until every *installed* system software dependency (e.g. PHP) has
+		// caught up with its desired version. A configuration change such as a
+		// PHP version bump takes the app offline for a while; the desired version
+		// is recorded synchronously by the PATCH while the installed version lags
+		// behind, so this reliably detects an update that is still being applied.
+		//
+		// We deliberately ignore entries whose current version is nil: those are
+		// merely *suggested* dependencies that are not installed yet and only get
+		// installed once they are explicitly configured via PATCH. Waiting for
+		// them here would deadlock the create flow, which has to reach a ready
+		// state before it is allowed to send that PATCH in the first place.
+		for _, software := range inst.SystemSoftware {
+			version := software.SystemSoftwareVersion
+			if version.Current != nil && *version.Current != version.Desired {
+				return notReady("system software version not converged", map[string]any{
+					"system_software":         software.Name,
+					"system_software_id":      software.SystemSoftwareId,
+					"system_software_current": strOrNil(version.Current),
+					"system_software_desired": version.Desired,
+				})
+			}
+		}
+
+		tflog.Debug(ctx, "app installation is ready", map[string]any{"app_installation_id": inst.Id})
 
 		return inst, resp, nil
 	}

--- a/internal/provider/resource/appresource/resource.go
+++ b/internal/provider/resource/appresource/resource.go
@@ -208,6 +208,17 @@ func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp 
 	data.ID = types.StringValue(installation.Id)
 
 	try := providerutil.Try[any](&resp.Diagnostics, "error while updating app installation")
+
+	// A freshly requested app installation still needs to finish provisioning
+	// before the API accepts any mutating requests; patching it too early fails
+	// with "expected phase APP_PHASE_READY, current phase is APP_PHASE_UNSPECIFIED".
+	// Wait for the installation to become ready before applying the updaters and
+	// linking databases.
+	try.Do(appClient.WaitUntilAppInstallationIsReady(ctx, installation.Id))
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	try.Do(appClient.UpdateAppinstallation(ctx, installation.Id, appUpdaters...))
 
 	for _, database := range databases {
@@ -332,6 +343,12 @@ func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp 
 			))
 		}
 	}
+
+	// Applying an update (e.g. a PHP version bump) takes the app offline for a
+	// while. Wait until the installation is ready again before considering the
+	// resource updated, so that dependent resources (such as mittwald_remote_file)
+	// don't try to reach the app while it is still being reconfigured.
+	try.Do(appClient.WaitUntilAppInstallationIsReady(ctx, planData.ID.ValueString()))
 
 	resp.Diagnostics.Append(r.read(ctx, &planData)...)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &planData)...)


### PR DESCRIPTION
The app resource issued PATCH and database-link requests immediately after requesting an installation, which the API rejects until the installation reaches the "ready" phase ("expected phase APP_PHASE_READY, current phase is APP_PHASE_UNSPECIFIED"). It also never waited for an update (e.g. a PHP version bump) to finish, so dependent resources could hit the app while it was offline being reconfigured.

- Create now waits for the installation to become ready before patching it and linking databases.
- Update now waits for the installation to become ready again afterwards.
- WaitUntilAppInstallationIsReady additionally checks the installation phase and that every *installed* system software dependency has converged on its desired version. Not-yet-installed suggestions (current == nil) are ignored to avoid deadlocking create, which must reach a ready state before it can configure those dependencies via PATCH.
- Mutating calls (patch, link/unlink database) retry on the transient "expected phase APP_PHASE_READY" error the backend returns while it briefly leaves the ready phase to deploy the project environment.

Fixes #399
Fixes #402