### PR TITLE
fix(release): disable SBOM publishing temporarily to work around issues in terraform registry sync

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -60,8 +60,3 @@ release:
   # draft: true
 changelog:
   disable: true
-sboms:
-  - id: default
-    disable: false
-    documents:
-      - "${artifact}.spdx.json"


### PR DESCRIPTION
Relates to #422 