### PR TITLE
fix(container_stack): expose short_id for containers

### DIFF
--- a/docs/resources/container_stack.md
+++ b/docs/resources/container_stack.md
@@ -144,6 +144,7 @@ Optional:
 Read-Only:
 
 - `id` (String) The generated container ID
+- `short_id` (String) The short ID of the container
 
 <a id="nestedatt--containers--limits"></a>
 ### Nested Schema for `containers.limits`

--- a/internal/provider/resource/containerstack/model.go
+++ b/internal/provider/resource/containerstack/model.go
@@ -20,6 +20,7 @@ type UpdateScheduleModel struct {
 
 type ContainerModel struct {
 	ID                 types.String `tfsdk:"id"`
+	ShortID            types.String `tfsdk:"short_id"`
 	Image              types.String `tfsdk:"image"`
 	Description        types.String `tfsdk:"description"`
 	Command            types.List   `tfsdk:"command"`

--- a/internal/provider/resource/containerstack/model_api_from.go
+++ b/internal/provider/resource/containerstack/model_api_from.go
@@ -63,6 +63,7 @@ func fromAPIContainers(ctx context.Context, apiModel *containerv2.StackResponse,
 		state := service.PendingState
 		container := ContainerModel{
 			ID:          types.StringValue(service.Id),
+			ShortID:     types.StringValue(service.ShortId),
 			Image:       types.StringValue(image),
 			Description: types.StringValue(service.Description),
 			Command:     valueutil.ConvertStringSliceToList(state.Command),
@@ -130,6 +131,7 @@ func fromAPIUpdateSchedule(ctx context.Context, apiModel *containerv2.StackRespo
 var containerModelType = types.ObjectType{
 	AttrTypes: map[string]attr.Type{
 		"id":                    types.StringType,
+		"short_id":              types.StringType,
 		"image":                 types.StringType,
 		"description":           types.StringType,
 		"command":               types.ListType{ElemType: types.StringType},

--- a/internal/provider/resource/containerstack/model_api_from_test.go
+++ b/internal/provider/resource/containerstack/model_api_from_test.go
@@ -25,6 +25,8 @@ var apiModel = &containerv2.StackResponse{
 	Services: []containerv2.ServiceResponse{
 		{
 			ServiceName: "nginx",
+			Id:          "service-abc",
+			ShortId:     "s-nginx",
 			PendingState: containerv2.ServiceState{
 				Image: "nginx:latest",
 				Ports: []string{"80:8080/tcp", "443:8443/tcp", "3000/tcp"},
@@ -91,7 +93,11 @@ func TestFromAPIModel(t *testing.T) {
 
 	nginxContainer, ok := containers["nginx"].(types.Object)
 	g.Expect(ok).To(BeTrue())
-	g.Expect(nginxContainer).To(HaveStringAttr("image", "nginx:latest"))
+	g.Expect(nginxContainer).To(And(
+		HaveStringAttr("image", "nginx:latest"),
+		HaveStringAttr("id", "service-abc"),
+		HaveStringAttr("short_id", "s-nginx"),
+	))
 
 	// Validate ports
 	portsSet, ok := nginxContainer.Attributes()["ports"].(types.Set)

--- a/internal/provider/resource/containerstack/resource.go
+++ b/internal/provider/resource/containerstack/resource.go
@@ -60,6 +60,13 @@ func (r *Resource) Schema(_ context.Context, _ resource.SchemaRequest, resp *res
 								stringplanmodifier.UseNonNullStateForUnknown(),
 							},
 						},
+						"short_id": schema.StringAttribute{
+							Computed:            true,
+							MarkdownDescription: "The short ID of the container",
+							PlanModifiers: []planmodifier.String{
+								stringplanmodifier.UseNonNullStateForUnknown(),
+							},
+						},
 						"image": schema.StringAttribute{
 							Required: true,
 							MarkdownDescription: "The image to use for the container. Follows the usual Docker image format, " +


### PR DESCRIPTION
## Summary

Relates to #431 

The `mittwald_container_stack.containers[*].short_id` field was missing. This adds it as a computed attribute, mirroring how `mittwald_project.short_id` behaves.

- Added a `ShortID` field to `ContainerModel`
- Registered a computed `short_id` string attribute in the container schema (with `UseNonNullStateForUnknown`, matching the sibling `id` attribute)
- Populated it from the API's `ServiceResponse.ShortId` field
- Regenerated the resource documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)