### PR TITLE
fix(cronjob): resolve full container service ID from API short ID

### DIFF
--- a/internal/provider/resource/cronjobresource/model_api.go
+++ b/internal/provider/resource/cronjobresource/model_api.go
@@ -9,13 +9,17 @@ import (
 	"github.com/google/shlex"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	mittwaldv2 "github.com/mittwald/api-client-go/mittwaldv2/generated/clients"
+	"github.com/mittwald/api-client-go/mittwaldv2/generated/clients/containerclientv2"
 	"github.com/mittwald/api-client-go/mittwaldv2/generated/clients/cronjobclientv2"
+	"github.com/mittwald/api-client-go/mittwaldv2/generated/schemas/containerv2"
 	"github.com/mittwald/api-client-go/mittwaldv2/generated/schemas/cronjobv2"
+	"github.com/mittwald/terraform-provider-mittwald/internal/provider/providerutil"
 	"github.com/mittwald/terraform-provider-mittwald/internal/ptrutil"
 	"github.com/mittwald/terraform-provider-mittwald/internal/valueutil"
 )
 
-func (m *ResourceModel) FromAPIModel(ctx context.Context, apiModel *cronjobv2.Cronjob) (res diag.Diagnostics) {
+func (m *ResourceModel) FromAPIModel(ctx context.Context, apiModel *cronjobv2.Cronjob, client mittwaldv2.Client) (res diag.Diagnostics) {
 	m.ProjectID = valueutil.StringPtrOrNull(apiModel.ProjectId)
 	m.Description = types.StringValue(apiModel.Description)
 	m.Email = valueutil.StringPtrOrNull(apiModel.Email)
@@ -33,7 +37,11 @@ func (m *ResourceModel) FromAPIModel(ctx context.Context, apiModel *cronjobv2.Cr
 		}
 
 		if svcTarget := apiModel.Target.AlternativeServiceTargetResponse; svcTarget != nil {
-			m.Container = containerObjectFromAPI(ctx, &res, svcTarget.StackId, svcTarget.ServiceShortId)
+			// The API only returns the service's short ID here, but the Terraform
+			// state must always hold the full service ID. Resolve it by looking up
+			// the service, which accepts either the full or the short ID.
+			serviceID := resolveContainerServiceID(ctx, &res, client, svcTarget.StackId, svcTarget.ServiceShortId)
+			m.Container = containerObjectFromAPI(ctx, &res, svcTarget.StackId, serviceID)
 			m.Destination = destinationFromContainerCommand(ctx, &res, svcTarget.Command)
 			return
 		}
@@ -245,6 +253,27 @@ func destinationFromAppTarget(ctx context.Context, d *diag.Diagnostics, destinat
 	}
 
 	return types.ObjectNull(resourceDestinationAttrTypes)
+}
+
+// resolveContainerServiceID resolves the full service ID for a given service
+// short ID within a stack. The cron job API returns only the service's short ID
+// when a cron job targets a container, but the Terraform state must always hold
+// the full service ID (the user may have configured it as a full UUID). The
+// GetService endpoint accepts either the full or the short ID and returns the
+// full ID.
+func resolveContainerServiceID(ctx context.Context, d *diag.Diagnostics, client mittwaldv2.Client, stackID, serviceShortID string) string {
+	service := providerutil.
+		Try[*containerv2.ServiceResponse](d, "API error while fetching container service").
+		DoValResp(client.Container().GetService(ctx, containerclientv2.GetServiceRequest{
+			StackID:   stackID,
+			ServiceID: serviceShortID,
+		}))
+
+	if d.HasError() {
+		return serviceShortID
+	}
+
+	return service.Id
 }
 
 func containerObjectFromAPI(ctx context.Context, d *diag.Diagnostics, stackID, serviceID string) types.Object {

--- a/internal/provider/resource/cronjobresource/model_api_container_test.go
+++ b/internal/provider/resource/cronjobresource/model_api_container_test.go
@@ -2,13 +2,18 @@ package cronjobresource
 
 import (
 	"context"
+	"fmt"
+	"net/http"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	generatedv2 "github.com/mittwald/api-client-go/mittwaldv2/generated/clients"
+	"github.com/mittwald/api-client-go/mittwaldv2/generated/schemas/containerv2"
 	"github.com/mittwald/api-client-go/mittwaldv2/generated/schemas/cronjobv2"
+	"github.com/mittwald/api-client-go/pkg/httpclient_mock"
 	. "github.com/onsi/gomega"
 )
 
@@ -85,8 +90,10 @@ func TestFromAPIModelReadsContainerTarget(t *testing.T) {
 		},
 	}
 
+	client := mockClientWithService(t, "10184af5-6716-4e82-81d7-4b1cd317d147", "nginx", "8f3e6f9c-8c4f-4a2e-9b1a-9d7c1e2f3a4b")
+
 	var model ResourceModel
-	diags := model.FromAPIModel(ctx, apiModel)
+	diags := model.FromAPIModel(ctx, apiModel, client)
 	g.Expect(diags.HasError()).To(BeFalse())
 	g.Expect(model.AppID.IsNull()).To(BeTrue())
 
@@ -94,7 +101,8 @@ func TestFromAPIModelReadsContainerTarget(t *testing.T) {
 	diags.Append(model.Container.As(ctx, &containerModel, basetypes.ObjectAsOptions{})...)
 	g.Expect(diags.HasError()).To(BeFalse())
 	g.Expect(containerModel.StackID).To(Equal(types.StringValue("10184af5-6716-4e82-81d7-4b1cd317d147")))
-	g.Expect(containerModel.ServiceID).To(Equal(types.StringValue("nginx")))
+	// The API only returns the service's short ID, but the state must hold the full service ID.
+	g.Expect(containerModel.ServiceID).To(Equal(types.StringValue("8f3e6f9c-8c4f-4a2e-9b1a-9d7c1e2f3a4b")))
 
 	dest := model.GetDestination(ctx, &diags)
 	g.Expect(diags.HasError()).To(BeFalse())
@@ -125,7 +133,7 @@ func TestFromAPIModelReadsAppTarget(t *testing.T) {
 	}
 
 	var model ResourceModel
-	diags := model.FromAPIModel(ctx, apiModel)
+	diags := model.FromAPIModel(ctx, apiModel, emptyMockClient())
 	g.Expect(diags.HasError()).To(BeFalse())
 	g.Expect(model.AppID).To(Equal(types.StringValue("79a97ff5-c13e-4d76-a80f-d8f38a499f22")))
 	g.Expect(model.Container.IsNull()).To(BeTrue())
@@ -154,7 +162,7 @@ func TestFromAPIModelDeprecatedFallback(t *testing.T) {
 	}
 
 	var model ResourceModel
-	diags := model.FromAPIModel(ctx, apiModel)
+	diags := model.FromAPIModel(ctx, apiModel, emptyMockClient())
 	g.Expect(diags.HasError()).To(BeFalse())
 	g.Expect(model.AppID).To(Equal(types.StringValue("79a97ff5-c13e-4d76-a80f-d8f38a499f22")))
 	g.Expect(model.Container.IsNull()).To(BeTrue())
@@ -189,11 +197,38 @@ func TestFromAPIModelPrefersTargetOverDeprecatedFallback(t *testing.T) {
 		},
 	}
 
+	client := mockClientWithService(t, "10184af5-6716-4e82-81d7-4b1cd317d147", "nginx", "8f3e6f9c-8c4f-4a2e-9b1a-9d7c1e2f3a4b")
+
 	var model ResourceModel
-	diags := model.FromAPIModel(ctx, apiModel)
+	diags := model.FromAPIModel(ctx, apiModel, client)
 	g.Expect(diags.HasError()).To(BeFalse())
 	g.Expect(model.AppID.IsNull()).To(BeTrue())
 	g.Expect(model.Container.IsNull()).To(BeFalse())
+}
+
+// mockClientWithService returns an API client whose GetService endpoint resolves
+// the given service short ID within the stack to the given full service ID.
+func mockClientWithService(t *testing.T, stackID, serviceShortID, fullServiceID string) generatedv2.Client {
+	t.Helper()
+
+	runner := &httpclient_mock.MockRequestRunner{}
+	runner.ExpectRequest(
+		http.MethodGet,
+		fmt.Sprintf("/v2/stacks/%s/services/%s", stackID, serviceShortID),
+		httpclient_mock.WithJSONResponse(containerv2.ServiceResponse{
+			Id:      fullServiceID,
+			ShortId: serviceShortID,
+			StackId: stackID,
+		}),
+	)
+
+	return generatedv2.NewClient(runner)
+}
+
+// emptyMockClient returns an API client backed by a mock that expects no
+// requests. It is used for cases that never look up a container service.
+func emptyMockClient() generatedv2.Client {
+	return generatedv2.NewClient(&httpclient_mock.MockRequestRunner{})
 }
 
 func mustListValue(t *testing.T, values []string) types.List {

--- a/internal/provider/resource/cronjobresource/resource.go
+++ b/internal/provider/resource/cronjobresource/resource.go
@@ -121,7 +121,7 @@ func (r *Resource) read(ctx context.Context, data *ResourceModel) (res diag.Diag
 		return
 	}
 
-	res.Append(data.FromAPIModel(ctx, cronjob)...)
+	res.Append(data.FromAPIModel(ctx, cronjob, r.client)...)
 
 	return
 }


### PR DESCRIPTION
## Problem

When a `mittwald_cronjob` resource targets a container service, the user may configure the target using a full container service UUID. However, the cron job API returns only the service's **short ID** (`serviceShortId`) in the service target response. This short ID was written straight into the Terraform state, causing a perpetual diff whenever the configuration uses the full service ID.

## Fix

When mapping the API model back to the resource (`FromAPIModel`), resolve the returned service short ID back to the full service ID via the `GetService` endpoint (which resolves either the full or the short ID). The Terraform state now always holds the full service ID, never the short ID.

- `FromAPIModel` now takes the API client so it can perform the lookup (mirroring the existing pattern in `appresource`).
- Added `resolveContainerServiceID` helper.
- Updated unit tests to assert the short ID is resolved to the full service ID, using a mock-backed client.

🤖 Generated with [Claude Code](https://claude.com/claude-code)