### PR TITLE
fix(project): honour configurable timeouts and tolerate a missing default ingress

### DIFF
--- a/docs/data-sources/project.md
+++ b/docs/data-sources/project.md
@@ -65,4 +65,4 @@ resource "mittwald_virtualhost" "example" {
 
 Optional:
 
-- `read` (String) Time to wait when reading the project; this includes waiting for a not-yet-provisioned default ingress (and with it, the `default_ips` attribute) to become available. Defaults to 2 minutes.
+- `read` (String) Time to wait when reading the project. This is an upper bound for the (usually near-instant) API calls involved, including waiting for a not-yet-provisioned default ingress (and with it, the `default_ips` attribute) to become available; defaults to 2 minutes.

--- a/docs/data-sources/project.md
+++ b/docs/data-sources/project.md
@@ -51,6 +51,7 @@ resource "mittwald_virtualhost" "example" {
 
 - `id` (String) The project identifier (full UUID). Either `id` or `short_id` must be set.
 - `short_id` (String) The project short ID (for example `p-XXXXXX`). Either `id` or `short_id` must be set.
+- `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 
 ### Read-Only
 
@@ -58,3 +59,10 @@ resource "mittwald_virtualhost" "example" {
 - `description` (String) The project description.
 - `directories` (Map of String) Contains a map of data directories within the project.
 - `server_id` (String) ID of the server this project belongs to. Null for stand-alone projects.
+
+<a id="nestedblock--timeouts"></a>
+### Nested Schema for `timeouts`
+
+Optional:
+
+- `read` (String) Time to wait when reading the project; this includes waiting for a not-yet-provisioned default ingress (and with it, the `default_ips` attribute) to become available. Defaults to 2 minutes.

--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -16,6 +16,14 @@ This resource models a project on the mittwald cloud platform; a project is eith
 resource "mittwald_project" "foobar" {
   server_id   = var.server_id
   description = "Test project"
+
+  # A project's default ingress (and with it, the `default_ips` attribute) is
+  # provisioned asynchronously; if this regularly takes longer than the default
+  # timeouts, you can adjust them here.
+  timeouts {
+    create = "10m"
+    read   = "2m"
+  }
 }
 
 output "project_ips" {
@@ -33,6 +41,7 @@ output "project_ips" {
 ### Optional
 
 - `server_id` (String) ID of the server this project belongs to. Must be a full UUID (not a short ID like s-XXXXXX).
+- `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 
 ### Read-Only
 
@@ -40,3 +49,11 @@ output "project_ips" {
 - `directories` (Map of String) Contains a map of data directories within the project
 - `id` (String) The generated project ID
 - `short_id` (String) The short ID of the project
+
+<a id="nestedblock--timeouts"></a>
+### Nested Schema for `timeouts`
+
+Optional:
+
+- `create` (String) Time to wait for the project to be created. This includes waiting for the project's default ingress (and with it, the `default_ips` attribute) to become available; defaults to 10 minutes.
+- `read` (String) Time to wait when reading the project's current state; defaults to 2 minutes.

--- a/docs/resources/project.md
+++ b/docs/resources/project.md
@@ -18,8 +18,9 @@ resource "mittwald_project" "foobar" {
   description = "Test project"
 
   # A project's default ingress (and with it, the `default_ips` attribute) is
-  # provisioned asynchronously; if this regularly takes longer than the default
-  # timeouts, you can adjust them here.
+  # provisioned asynchronously. This usually takes just a few seconds -- the
+  # timeouts below are upper bounds, not waiting times -- but if provisioning
+  # regularly takes longer than the defaults, you can adjust them here.
   timeouts {
     create = "10m"
     read   = "2m"
@@ -55,5 +56,5 @@ output "project_ips" {
 
 Optional:
 
-- `create` (String) Time to wait for the project to be created. This includes waiting for the project's default ingress (and with it, the `default_ips` attribute) to become available; defaults to 10 minutes.
-- `read` (String) Time to wait when reading the project's current state; defaults to 2 minutes.
+- `create` (String) Time to wait for the project to be created. This includes waiting for the project's default ingress (and with it, the `default_ips` attribute) to become available, which usually takes just a few seconds, but can occasionally take several minutes. Defaults to 10 minutes; this is only an upper bound, and creation returns as soon as the project is ready.
+- `read` (String) Time to wait when reading the project's current state. This is an upper bound for the (usually near-instant) API calls involved, including waiting for a not-yet-provisioned default ingress; defaults to 2 minutes.

--- a/examples/resources/mittwald_project/resource.tf
+++ b/examples/resources/mittwald_project/resource.tf
@@ -3,8 +3,9 @@ resource "mittwald_project" "foobar" {
   description = "Test project"
 
   # A project's default ingress (and with it, the `default_ips` attribute) is
-  # provisioned asynchronously; if this regularly takes longer than the default
-  # timeouts, you can adjust them here.
+  # provisioned asynchronously. This usually takes just a few seconds -- the
+  # timeouts below are upper bounds, not waiting times -- but if provisioning
+  # regularly takes longer than the defaults, you can adjust them here.
   timeouts {
     create = "10m"
     read   = "2m"

--- a/examples/resources/mittwald_project/resource.tf
+++ b/examples/resources/mittwald_project/resource.tf
@@ -1,6 +1,14 @@
 resource "mittwald_project" "foobar" {
   server_id   = var.server_id
   description = "Test project"
+
+  # A project's default ingress (and with it, the `default_ips` attribute) is
+  # provisioned asynchronously; if this regularly takes longer than the default
+  # timeouts, you can adjust them here.
+  timeouts {
+    create = "10m"
+    read   = "2m"
+  }
 }
 
 output "project_ips" {

--- a/go.mod
+++ b/go.mod
@@ -50,6 +50,7 @@ require (
 	github.com/hashicorp/logutils v1.0.0 // indirect
 	github.com/hashicorp/terraform-exec v0.25.1 // indirect
 	github.com/hashicorp/terraform-json v0.27.3-0.20260213134036-298b8f6b673a // indirect
+	github.com/hashicorp/terraform-plugin-framework-timeouts v0.7.0 // indirect
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.40.1 // indirect
 	github.com/hashicorp/terraform-registry-address v0.4.0 // indirect
 	github.com/hashicorp/terraform-svchost v0.2.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -119,6 +119,8 @@ github.com/hashicorp/terraform-plugin-docs v0.25.0 h1:qHs1V257NxVe8tv6HS4UQfNqja
 github.com/hashicorp/terraform-plugin-docs v0.25.0/go.mod h1:MQggCmY8zgP7R7E/cC0b0cmTvA9hSj3ZKyrrsDjRbLo=
 github.com/hashicorp/terraform-plugin-framework v1.19.0 h1:q0bwyhxAOR3vfdgbk9iplv3MlTv/dhBHTXjQOtQDoBA=
 github.com/hashicorp/terraform-plugin-framework v1.19.0/go.mod h1:YRXOBu0jvs7xp4AThBbX4mAzYaMJ1JgtFH//oGKxwLc=
+github.com/hashicorp/terraform-plugin-framework-timeouts v0.7.0 h1:jblRy1PkLfPm5hb5XeMa3tezusnMRziUGqtT5epSYoI=
+github.com/hashicorp/terraform-plugin-framework-timeouts v0.7.0/go.mod h1:5jm2XK8uqrdiSRfD5O47OoxyGMCnwTcl8eoiDgSa+tc=
 github.com/hashicorp/terraform-plugin-go v0.31.0 h1:0Fz2r9DQ+kNNl6bx8HRxFd1TfMKUvnrOtvJPmp3Z0q8=
 github.com/hashicorp/terraform-plugin-go v0.31.0/go.mod h1:A88bDhd/cW7FnwqxQRz3slT+QY6yzbHKc6AOTtmdeS8=
 github.com/hashicorp/terraform-plugin-log v0.10.0 h1:eu2kW6/QBVdN4P3Ju2WiB2W3ObjkAsyfBsL3Wh1fj3g=

--- a/internal/apiext/project_client.go
+++ b/internal/apiext/project_client.go
@@ -7,6 +7,7 @@ import (
 	mittwaldv2 "github.com/mittwald/api-client-go/mittwaldv2/generated/clients"
 	"github.com/mittwald/api-client-go/mittwaldv2/generated/clients/domainclientv2"
 	"github.com/mittwald/api-client-go/mittwaldv2/generated/clients/projectclientv2"
+	"github.com/mittwald/terraform-provider-mittwald/internal/apiutils"
 )
 
 // ErrNoDefaultIngress is returned when a project does not have a default ingress yet,
@@ -17,6 +18,7 @@ type ProjectClient interface {
 	projectclientv2.Client
 
 	GetProjectDefaultIPs(context.Context, string) ([]string, error)
+	PollProjectDefaultIPs(context.Context, string) ([]string, error)
 }
 
 type projectClient struct {
@@ -49,4 +51,28 @@ func (c *projectClient) GetProjectDefaultIPs(ctx context.Context, projectID stri
 	}
 
 	return nil, ErrNoDefaultIngress
+}
+
+// PollProjectDefaultIPs polls for the project's default IP addresses until they
+// become available, or until the context is done. Since the default ingress is
+// created asynchronously after a project is created, this may take a while.
+//
+// If the context expires before the default ingress becomes available, this
+// method returns ErrNoDefaultIngress; callers can use this to distinguish "not
+// (yet) available" from an actual API error, and degrade gracefully.
+func (c *projectClient) PollProjectDefaultIPs(ctx context.Context, projectID string) ([]string, error) {
+	pollIPs := func(ctx context.Context, projectID string) ([]string, error) {
+		ips, err := c.GetProjectDefaultIPs(ctx, projectID)
+		if errors.Is(err, ErrNoDefaultIngress) {
+			return nil, apiutils.ErrPollShouldRetry
+		}
+		return ips, err
+	}
+
+	ips, err := apiutils.Poll(ctx, apiutils.PollOpts{}, pollIPs, projectID)
+	if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+		return nil, ErrNoDefaultIngress
+	}
+
+	return ips, err
 }

--- a/internal/provider/datasource/projectdatasource/datasource.go
+++ b/internal/provider/datasource/projectdatasource/datasource.go
@@ -3,6 +3,7 @@ package projectdatasource
 import (
 	"context"
 
+	"github.com/hashicorp/terraform-plugin-framework-timeouts/datasource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework/datasource"
 	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -29,11 +30,23 @@ type DataSource struct {
 	client mittwaldv2.Client
 }
 
+// dataSourceModel extends the shared project model with the data source's
+// `timeouts` block.
+type dataSourceModel struct {
+	projectresource.ResourceModel
+
+	Timeouts timeouts.Value `tfsdk:"timeouts"`
+}
+
+// readTimeoutHint is appended to diagnostics caused by an exhausted read
+// timeout, to point users at the knob they can turn.
+const readTimeoutHint = "If this happens regularly, increase the `timeouts.read` value on this data source."
+
 func (d *DataSource) Metadata(_ context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
 	resp.TypeName = req.ProviderTypeName + "_project"
 }
 
-func (d *DataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+func (d *DataSource) Schema(ctx context.Context, _ datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		MarkdownDescription: "Selects an existing project on the mittwald cloud platform.\n\n" +
 			"Exactly one of `id` or `short_id` must be set; the other is populated from the API, " +
@@ -71,6 +84,14 @@ func (d *DataSource) Schema(_ context.Context, _ datasource.SchemaRequest, resp 
 				ElementType:         types.StringType,
 			},
 		},
+
+		Blocks: map[string]schema.Block{
+			"timeouts": timeouts.BlockWithOpts(ctx, timeouts.Opts{
+				ReadDescription: "Time to wait when reading the project; this includes waiting for a " +
+					"not-yet-provisioned default ingress (and with it, the `default_ips` attribute) to become " +
+					"available. Defaults to 2 minutes.",
+			}),
+		},
 	}
 }
 
@@ -81,12 +102,22 @@ func (d *DataSource) Configure(_ context.Context, req datasource.ConfigureReques
 func (d *DataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
 	// Reuse the resource model and its API mapping so the data source and the
 	// mittwald_project resource cannot drift when project attributes change.
-	var data projectresource.ResourceModel
+	var data dataSourceModel
 
 	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	readTimeout, diags := data.Timeouts.Read(ctx, projectresource.DefaultReadTimeout)
+	resp.Diagnostics.Append(diags...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, readTimeout)
+	defer cancel()
 
 	// The mittwald API resolves both full and short IDs through the same
 	// endpoint, so either value can be passed straight through to GetProject.
@@ -106,10 +137,9 @@ func (d *DataSource) Read(ctx context.Context, req datasource.ReadRequest, resp 
 		return
 	}
 
-	ips := providerutil.
-		Try[[]string](&resp.Diagnostics, "error while reading project ips").
-		IgnoreNotFound().
-		DoVal(client.GetProjectDefaultIPs(ctx, project.Id))
+	// A missing default ingress is not an error; the project's IP addresses may
+	// simply not be available yet.
+	ips := projectresource.PollDefaultIPs(ctx, client, project.Id, readTimeoutHint, &resp.Diagnostics)
 
 	if resp.Diagnostics.HasError() {
 		return

--- a/internal/provider/datasource/projectdatasource/datasource.go
+++ b/internal/provider/datasource/projectdatasource/datasource.go
@@ -87,9 +87,10 @@ func (d *DataSource) Schema(ctx context.Context, _ datasource.SchemaRequest, res
 
 		Blocks: map[string]schema.Block{
 			"timeouts": timeouts.BlockWithOpts(ctx, timeouts.Opts{
-				ReadDescription: "Time to wait when reading the project; this includes waiting for a " +
-					"not-yet-provisioned default ingress (and with it, the `default_ips` attribute) to become " +
-					"available. Defaults to 2 minutes.",
+				ReadDescription: "Time to wait when reading the project. This is an upper bound for the " +
+					"(usually near-instant) API calls involved, including waiting for a not-yet-provisioned " +
+					"default ingress (and with it, the `default_ips` attribute) to become available; " +
+					"defaults to 2 minutes.",
 			}),
 		},
 	}

--- a/internal/provider/datasource/projectdatasource/schema_test.go
+++ b/internal/provider/datasource/projectdatasource/schema_test.go
@@ -1,0 +1,46 @@
+package projectdatasource
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	. "github.com/onsi/gomega"
+)
+
+// TestDataSourceModelMatchesSchema asserts that the data source model (which
+// embeds the shared project model) can actually be filled from a config object
+// built from the data source schema.
+func TestDataSourceModelMatchesSchema(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+
+	ds, ok := New().(*DataSource)
+	g.Expect(ok).To(BeTrue())
+
+	resp := datasource.SchemaResponse{}
+	ds.Schema(ctx, datasource.SchemaRequest{}, &resp)
+
+	g.Expect(resp.Diagnostics.HasError()).To(BeFalse())
+
+	objectType, ok := resp.Schema.Type().TerraformType(ctx).(tftypes.Object)
+	g.Expect(ok).To(BeTrue())
+	attributes := make(map[string]tftypes.Value, len(objectType.AttributeTypes))
+
+	for name, attributeType := range objectType.AttributeTypes {
+		attributes[name] = tftypes.NewValue(attributeType, nil)
+	}
+
+	config := tfsdk.Config{
+		Schema: resp.Schema,
+		Raw:    tftypes.NewValue(objectType, attributes),
+	}
+
+	var data dataSourceModel
+
+	g.Expect(config.Get(ctx, &data)).To(BeEmpty())
+	g.Expect(data.ID.IsNull()).To(BeTrue())
+	g.Expect(data.Timeouts.IsNull()).To(BeTrue())
+}

--- a/internal/provider/resource/projectresource/default_ips.go
+++ b/internal/provider/resource/projectresource/default_ips.go
@@ -3,30 +3,10 @@ package projectresource
 import (
 	"context"
 	"errors"
-	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/mittwald/api-client-go/pkg/httperr"
 	"github.com/mittwald/terraform-provider-mittwald/internal/apiext"
-)
-
-const (
-	// DefaultCreateTimeout is the default timeout for creating a project. Most
-	// of it is spent waiting for the project's default ingress (and its IP
-	// addresses) to be provisioned, which is done asynchronously by the
-	// platform and can occasionally take several minutes.
-	DefaultCreateTimeout = 10 * time.Minute
-
-	// DefaultReadTimeout is the default timeout for reading a project. It also
-	// covers waiting for a not-yet-provisioned default ingress; if the ingress
-	// does not show up in time, the read degrades to an empty list of default
-	// IP addresses instead of failing.
-	DefaultReadTimeout = 2 * time.Minute
-
-	// createTimeoutHint and readTimeoutHint are appended to diagnostics that are
-	// caused by an exhausted timeout, to point users at the knob they can turn.
-	createTimeoutHint = "If this happens regularly, increase the `timeouts.create` value on this resource."
-	readTimeoutHint   = "If this happens regularly, increase the `timeouts.read` value on this resource."
 )
 
 // PollDefaultIPs waits for the default IP addresses of a project to become

--- a/internal/provider/resource/projectresource/default_ips.go
+++ b/internal/provider/resource/projectresource/default_ips.go
@@ -1,0 +1,68 @@
+package projectresource
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/mittwald/api-client-go/pkg/httperr"
+	"github.com/mittwald/terraform-provider-mittwald/internal/apiext"
+)
+
+const (
+	// DefaultCreateTimeout is the default timeout for creating a project. Most
+	// of it is spent waiting for the project's default ingress (and its IP
+	// addresses) to be provisioned, which is done asynchronously by the
+	// platform and can occasionally take several minutes.
+	DefaultCreateTimeout = 10 * time.Minute
+
+	// DefaultReadTimeout is the default timeout for reading a project. It also
+	// covers waiting for a not-yet-provisioned default ingress; if the ingress
+	// does not show up in time, the read degrades to an empty list of default
+	// IP addresses instead of failing.
+	DefaultReadTimeout = 2 * time.Minute
+
+	// createTimeoutHint and readTimeoutHint are appended to diagnostics that are
+	// caused by an exhausted timeout, to point users at the knob they can turn.
+	createTimeoutHint = "If this happens regularly, increase the `timeouts.create` value on this resource."
+	readTimeoutHint   = "If this happens regularly, increase the `timeouts.read` value on this resource."
+)
+
+// PollDefaultIPs waits for the default IP addresses of a project to become
+// available, until the given context is done.
+//
+// A project's default ingress is provisioned asynchronously, so it may not
+// exist yet (or may not have IP addresses assigned yet). This is not treated as
+// an error: if the ingress does not become available in time, this function
+// emits a warning and returns no addresses, so that the caller can still
+// persist the remaining project attributes. The same applies when the ingress
+// is not visible due to insufficient permissions.
+func PollDefaultIPs(ctx context.Context, client apiext.ProjectClient, projectID string, timeoutHint string, res *diag.Diagnostics) []string {
+	ips, err := client.PollProjectDefaultIPs(ctx, projectID)
+	if err == nil {
+		return ips
+	}
+
+	if errors.Is(err, apiext.ErrNoDefaultIngress) {
+		res.AddWarning(
+			"Project has no default IP addresses (yet)",
+			"The default ingress of project "+projectID+" did not become available in time, so the "+
+				"`default_ips` attribute is empty. This usually resolves itself; the addresses should show up on "+
+				"the next `terraform refresh` or `terraform apply`.\n\n"+timeoutHint,
+		)
+		return nil
+	}
+
+	if notFound := new(httperr.ErrNotFound); errors.As(err, &notFound) {
+		return nil
+	}
+
+	if permissionDenied := new(httperr.ErrPermissionDenied); errors.As(err, &permissionDenied) {
+		return nil
+	}
+
+	res.AddError("error while reading project ips", err.Error())
+
+	return nil
+}

--- a/internal/provider/resource/projectresource/model.go
+++ b/internal/provider/resource/projectresource/model.go
@@ -1,11 +1,15 @@
 package projectresource
 
 import (
+	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
-// ResourceModel describes the resource data model.
+// ResourceModel describes the resource data model. It is shared with the
+// mittwald_project data source, so that both cannot drift apart; the timeouts
+// configuration is kept out of it, because resources and data sources use
+// distinct types for it.
 type ResourceModel struct {
 	ID          types.String `tfsdk:"id"`
 	ShortID     types.String `tfsdk:"short_id"`
@@ -13,6 +17,14 @@ type ResourceModel struct {
 	Description types.String `tfsdk:"description"`
 	Directories types.Map    `tfsdk:"directories"`
 	DefaultIPs  types.List   `tfsdk:"default_ips"`
+}
+
+// ResourceModelWithTimeouts is the model actually used by the resource; it
+// extends ResourceModel with the resource's `timeouts` block.
+type ResourceModelWithTimeouts struct {
+	ResourceModel
+
+	Timeouts timeouts.Value `tfsdk:"timeouts"`
 }
 
 func (m *ResourceModel) Validate() (d diag.Diagnostics) {

--- a/internal/provider/resource/projectresource/model_api.go
+++ b/internal/provider/resource/projectresource/model_api.go
@@ -12,6 +12,7 @@ import (
 
 func (m *ResourceModel) Reset() {
 	m.ID = types.StringNull()
+	m.ShortID = types.StringNull()
 	m.ServerID = types.StringNull()
 	m.Description = types.StringNull()
 	m.Directories = types.MapNull(types.StringType)

--- a/internal/provider/resource/projectresource/resource.go
+++ b/internal/provider/resource/projectresource/resource.go
@@ -85,10 +85,14 @@ func (r *Resource) Schema(ctx context.Context, _ resource.SchemaRequest, resp *r
 			"timeouts": timeouts.Block(ctx, timeouts.Opts{
 				Create: true,
 				CreateDescription: "Time to wait for the project to be created. This includes waiting for the " +
-					"project's default ingress (and with it, the `default_ips` attribute) to become available; " +
-					"defaults to 10 minutes.",
-				Read:            true,
-				ReadDescription: "Time to wait when reading the project's current state; defaults to 2 minutes.",
+					"project's default ingress (and with it, the `default_ips` attribute) to become available, " +
+					"which usually takes just a few seconds, but can occasionally take several minutes. " +
+					"Defaults to 10 minutes; this is only an upper bound, and creation returns as soon as the " +
+					"project is ready.",
+				Read: true,
+				ReadDescription: "Time to wait when reading the project's current state. This is an upper bound " +
+					"for the (usually near-instant) API calls involved, including waiting for a " +
+					"not-yet-provisioned default ingress; defaults to 2 minutes.",
 			}),
 		},
 	}

--- a/internal/provider/resource/projectresource/resource.go
+++ b/internal/provider/resource/projectresource/resource.go
@@ -3,8 +3,8 @@ package projectresource
 import (
 	"context"
 	"errors"
-	"time"
 
+	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -41,7 +41,7 @@ func (r *Resource) Metadata(_ context.Context, req resource.MetadataRequest, res
 	resp.TypeName = req.ProviderTypeName + "_project"
 }
 
-func (r *Resource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+func (r *Resource) Schema(ctx context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	builder := common.AttributeBuilderFor("project")
 	resp.Schema = schema.Schema{
 		MarkdownDescription: "This resource models a project on the mittwald cloud platform; a project is either provisioned on a server (in which case a `server_id` is required), or as a stand-alone project (currently not supported).",
@@ -80,6 +80,17 @@ func (r *Resource) Schema(_ context.Context, _ resource.SchemaRequest, resp *res
 				},
 			},
 		},
+
+		Blocks: map[string]schema.Block{
+			"timeouts": timeouts.Block(ctx, timeouts.Opts{
+				Create: true,
+				CreateDescription: "Time to wait for the project to be created. This includes waiting for the " +
+					"project's default ingress (and with it, the `default_ips` attribute) to become available; " +
+					"defaults to 10 minutes.",
+				Read:            true,
+				ReadDescription: "Time to wait when reading the project's current state; defaults to 2 minutes.",
+			}),
+		},
 	}
 }
 
@@ -88,7 +99,7 @@ func (r *Resource) Configure(_ context.Context, req resource.ConfigureRequest, r
 }
 
 func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
-	var data ResourceModel
+	var data ResourceModelWithTimeouts
 
 	client := r.client.Project()
 
@@ -98,6 +109,16 @@ func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp 
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	createTimeout, diags := data.Timeouts.Create(ctx, DefaultCreateTimeout)
+	resp.Diagnostics.Append(diags...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, createTimeout)
+	defer cancel()
 
 	projectResponse := providerutil.
 		Try[*projectclientv2.CreateProjectResponse](&resp.Diagnostics, "error while creating project").
@@ -112,12 +133,17 @@ func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp 
 
 	data.ID = types.StringValue(projectResponse.Id)
 
-	resp.Diagnostics.Append(r.readAfterCreate(ctx, &data)...)
+	resp.Diagnostics.Append(r.readAfterCreate(ctx, &data.ResourceModel)...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
 func (r *Resource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
-	var data ResourceModel
+	var data ResourceModelWithTimeouts
 
 	// Read Terraform prior state data into the model
 	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
@@ -126,63 +152,92 @@ func (r *Resource) Read(ctx context.Context, req resource.ReadRequest, resp *res
 		return
 	}
 
-	readCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
+	readTimeout, diags := data.Timeouts.Read(ctx, DefaultReadTimeout)
+	resp.Diagnostics.Append(diags...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	readCtx, cancel := context.WithTimeout(ctx, readTimeout)
 	defer cancel()
 
-	resp.Diagnostics.Append(r.read(readCtx, &data)...)
+	found, diags := r.read(readCtx, &data.ResourceModel)
+	resp.Diagnostics.Append(diags...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if !found {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
-func (r *Resource) read(ctx context.Context, data *ResourceModel) (res diag.Diagnostics) {
+// read refreshes the given model from the API. It reports whether the project
+// still exists; if it does not, the model is left untouched and the caller
+// should remove the resource from the state.
+func (r *Resource) read(ctx context.Context, data *ResourceModel) (bool, diag.Diagnostics) {
+	var res diag.Diagnostics
+
 	client := apiext.NewProjectClient(r.client)
 
 	pr := providerutil.
 		Try[*projectv2.Project](&res, "error while reading project").
 		IgnoreNotFound().
-		DoVal(apiutils.PollRequest(ctx, apiutils.PollOpts{}, client.GetProject, projectclientv2.GetProjectRequest{ProjectID: data.ID.ValueString()}))
+		DoValResp(client.GetProject(ctx, projectclientv2.GetProjectRequest{ProjectID: data.ID.ValueString()}))
 
-	ips := providerutil.
-		Try[[]string](&res, "error while reading project ips").
-		IgnoreNotFound().
-		DoVal(client.GetProjectDefaultIPs(ctx, data.ID.ValueString()))
+	if res.HasError() || pr == nil {
+		return false, res
+	}
+
+	// A missing default ingress is not an error during a refresh; it just means
+	// that the project's IP addresses are not available (yet).
+	ips := PollDefaultIPs(ctx, client, data.ID.ValueString(), readTimeoutHint, &res)
 
 	if res.HasError() {
-		return
+		return false, res
 	}
 
 	res.Append(data.FromAPIModel(ctx, pr, ips)...)
 
-	return
+	return true, res
 }
 
-// readAfterCreate is like read but polls for the default IPs to become available.
-// This is necessary because immediately after project creation, the default ingress
-// may not exist yet.
+// readAfterCreate is like read, but tolerates the project itself not being
+// visible right away, and waits longer for the default IPs to become available.
+// This is necessary because immediately after project creation, neither the
+// project nor its default ingress may be visible yet.
 func (r *Resource) readAfterCreate(ctx context.Context, data *ResourceModel) (res diag.Diagnostics) {
 	client := apiext.NewProjectClient(r.client)
 
-	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
-	defer cancel()
-
-	pr := providerutil.
-		Try[*projectv2.Project](&res, "error while reading project").
-		IgnoreNotFound().
-		DoVal(apiutils.PollRequest(ctx, apiutils.PollOpts{}, client.GetProject, projectclientv2.GetProjectRequest{ProjectID: data.ID.ValueString()}))
-
-	// Wrap GetProjectDefaultIPs to convert ErrNoDefaultIngress to ErrPollShouldRetry
-	// so that the Poll function will retry until the default ingress appears.
-	getIPsWithRetry := func(ctx context.Context, projectID string) ([]string, error) {
-		ips, err := client.GetProjectDefaultIPs(ctx, projectID)
-		if errors.Is(err, apiext.ErrNoDefaultIngress) {
-			return nil, apiutils.ErrPollShouldRetry
+	pr, err := apiutils.PollRequest(ctx, apiutils.PollOpts{}, client.GetProject, projectclientv2.GetProjectRequest{ProjectID: data.ID.ValueString()})
+	if err != nil {
+		if errors.Is(err, context.DeadlineExceeded) {
+			res.AddError(
+				"error while reading project",
+				"the project was created, but did not become readable in time. "+createTimeoutHint,
+			)
+		} else {
+			res.AddError("error while reading project", err.Error())
 		}
-		return ips, err
+
+		return
 	}
 
-	ips := providerutil.
-		Try[[]string](&res, "error while reading project ips").
-		IgnoreNotFound().
-		DoVal(apiutils.Poll(ctx, apiutils.PollOpts{}, getIPsWithRetry, data.ID.ValueString()))
+	if pr == nil {
+		res.AddError("error while reading project", "the project was created, but could not be read back")
+		return
+	}
+
+	// If the default ingress does not show up in time, continue with an empty
+	// list of IP addresses; the project itself has been created successfully,
+	// and failing here would leave the resource tainted (and all computed
+	// attributes unknown, which Terraform rejects outright).
+	ips := PollDefaultIPs(ctx, client, data.ID.ValueString(), createTimeoutHint, &res)
 
 	if res.HasError() {
 		return
@@ -194,7 +249,7 @@ func (r *Resource) readAfterCreate(ctx context.Context, data *ResourceModel) (re
 }
 
 func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	var dataPlan, dataState ResourceModel
+	var dataPlan, dataState ResourceModelWithTimeouts
 
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &dataPlan)...)
 	resp.Diagnostics.Append(req.State.Get(ctx, &dataState)...)
@@ -224,7 +279,7 @@ func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp 
 }
 
 func (r *Resource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
-	var data ResourceModel
+	var data ResourceModelWithTimeouts
 
 	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
 

--- a/internal/provider/resource/projectresource/schema_test.go
+++ b/internal/provider/resource/projectresource/schema_test.go
@@ -1,0 +1,47 @@
+package projectresource_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	. "github.com/onsi/gomega"
+
+	"github.com/mittwald/terraform-provider-mittwald/internal/provider/resource/projectresource"
+)
+
+// TestResourceModelMatchesSchema asserts that the resource model (including the
+// embedded shared model and the timeouts block) can actually be filled from a
+// state object built from the resource schema.
+func TestResourceModelMatchesSchema(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+
+	res := projectresource.New()
+
+	resp := resource.SchemaResponse{}
+	res.Schema(ctx, resource.SchemaRequest{}, &resp)
+
+	g.Expect(resp.Diagnostics.HasError()).To(BeFalse())
+
+	objectType, ok := resp.Schema.Type().TerraformType(ctx).(tftypes.Object)
+	g.Expect(ok).To(BeTrue())
+	attributes := make(map[string]tftypes.Value, len(objectType.AttributeTypes))
+
+	for name, attributeType := range objectType.AttributeTypes {
+		attributes[name] = tftypes.NewValue(attributeType, nil)
+	}
+
+	state := tfsdk.State{
+		Schema: resp.Schema,
+		Raw:    tftypes.NewValue(objectType, attributes),
+	}
+
+	var data projectresource.ResourceModelWithTimeouts
+
+	g.Expect(state.Get(ctx, &data)).To(BeEmpty())
+	g.Expect(data.ID.IsNull()).To(BeTrue())
+	g.Expect(data.Timeouts.IsNull()).To(BeTrue())
+}

--- a/internal/provider/resource/projectresource/timeouts.go
+++ b/internal/provider/resource/projectresource/timeouts.go
@@ -1,0 +1,23 @@
+package projectresource
+
+import "time"
+
+const (
+	// DefaultCreateTimeout is the default timeout for creating a project. Most
+	// of it is spent waiting for the project's default ingress (and its IP
+	// addresses) to be provisioned, which is done asynchronously by the
+	// platform. Usually, this takes just a few seconds; the timeout is only
+	// this generous to also cover the rare occasions on which it takes minutes.
+	DefaultCreateTimeout = 10 * time.Minute
+
+	// DefaultReadTimeout is the default timeout for reading a project. It also
+	// covers waiting for a not-yet-provisioned default ingress; if the ingress
+	// does not show up in time, the read degrades to an empty list of default
+	// IP addresses instead of failing.
+	DefaultReadTimeout = 2 * time.Minute
+
+	// createTimeoutHint and readTimeoutHint are appended to diagnostics that are
+	// caused by an exhausted timeout, to point users at the knob they can turn.
+	createTimeoutHint = "If this happens regularly, increase the `timeouts.create` value on this resource."
+	readTimeoutHint   = "If this happens regularly, increase the `timeouts.read` value on this resource."
+)


### PR DESCRIPTION
Closes #447.

## Problem

The `mittwald_project` resource waited for the asynchronously provisioned default ingress with hard-coded budgets: 30s after create, 3s on read. Exceeding either failed the whole operation:

- after create, `readAfterCreate` returned early without mapping the API response, so `short_id`, `directories` and `default_ips` stayed unknown → *"Provider returned invalid result object after apply"*, resource tainted, project orphaned on the naive retry;
- on refresh, either `context deadline exceeded` or a hard `project does not have a default ingress`, because `ErrNoDefaultIngress` is a plain sentinel that `IgnoreNotFound()` does not match — which also blocked the `-refresh-only` recovery path.

## Changes

- **Configurable timeouts.** Both the resource (`create`, `read`) and the `mittwald_project` data source (`read`) now expose a `timeouts` block, via `terraform-plugin-framework-timeouts`. Defaults are more generous than the previous hard-coded values: **10m** for create, **2m** for read.
- **Graceful degradation.** A default ingress that does not become available within the timeout is no longer an error anywhere: `PollDefaultIPs` emits a warning (pointing at the relevant `timeouts` knob) and returns no addresses, so create still writes a fully-known state object and a refresh still succeeds.
- **`read` no longer polls `GetProject`.** Eventual consistency right after create is already handled by `readAfterCreate`; on refresh, a project that is gone is now removed from state instead of erroring out once the deadline expires.
- **`ResourceModel.Reset`** now also resets `short_id`, which it previously left untouched.
- The retry-until-available logic moved into `apiext.ProjectClient.PollProjectDefaultIPs`, shared by resource and data source.

The timeouts block cannot live in the shared `ResourceModel` (resource and data source use distinct `timeouts.Value` types), so both sides embed the shared model in a thin wrapper struct. Two unit tests assert that these wrappers still line up with their schemas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0175L18zL6zFXRRmFP8qbHmo