### PR TITLE
fix(apiutils): avoid "send on closed channel" panic in Poll

### DIFF
--- a/internal/apiutils/poll.go
+++ b/internal/apiutils/poll.go
@@ -43,56 +43,44 @@ func PollRequest[TReq any, TRes any](ctx context.Context, o PollOpts, f func(con
 func Poll[TParam any, TRes any](ctx context.Context, o PollOpts, f func(context.Context, TParam) (TRes, error), param TParam) (TRes, error) {
 	var null TRes
 
-	res := make(chan TRes)
-	err := make(chan error)
-
 	o.applyDefaults()
 
 	d := o.InitialDelay
 	t := time.NewTicker(d)
 
-	defer func() {
-		t.Stop()
-		close(res)
-		close(err)
-	}()
+	defer t.Stop()
 
-	go func() {
-		for {
-			if _, ok := <-t.C; !ok {
-				return
-			}
-
-			d = time.Duration(math.Min(float64(d)*o.BackoffFactor, float64(o.MaxDelay)))
-			t.Reset(d)
-
-			r, e := f(ctx, param)
-			if e == nil {
-				res <- r
-				return
-			}
-
-			if errors.Is(e, ErrPollShouldRetry) {
-				continue
-			} else if notFound := new(httperr.ErrNotFound); errors.As(e, &notFound) {
-				continue
-			} else if permissionDenied := new(httperr.ErrPermissionDenied); errors.As(e, &permissionDenied) {
-				continue
-			} else if errors.Is(e, context.DeadlineExceeded) {
-				return
-			} else {
-				err <- e
-				return
-			}
+	for {
+		select {
+		case <-ctx.Done():
+			return null, ctx.Err()
+		case <-t.C:
 		}
-	}()
 
-	select {
-	case <-ctx.Done():
-		return null, ctx.Err()
-	case r := <-res:
-		return r, nil
-	case e := <-err:
+		d = time.Duration(math.Min(float64(d)*o.BackoffFactor, float64(o.MaxDelay)))
+		t.Reset(d)
+
+		r, e := f(ctx, param)
+
+		// The polling function may have been in flight while the context was
+		// cancelled; in that case, the cancellation takes precedence over
+		// whatever it ended up returning.
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return null, ctxErr
+		}
+
+		if e == nil {
+			return r, nil
+		}
+
+		if errors.Is(e, ErrPollShouldRetry) {
+			continue
+		} else if notFound := new(httperr.ErrNotFound); errors.As(e, &notFound) {
+			continue
+		} else if permissionDenied := new(httperr.ErrPermissionDenied); errors.As(e, &permissionDenied) {
+			continue
+		}
+
 		tflog.Debug(ctx, "polling failed", map[string]any{"error": e})
 		return null, e
 	}

--- a/internal/apiutils/poll_test.go
+++ b/internal/apiutils/poll_test.go
@@ -1,0 +1,138 @@
+package apiutils_test
+
+import (
+	"context"
+	"errors"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/mittwald/terraform-provider-mittwald/internal/apiutils"
+)
+
+var testOpts = apiutils.PollOpts{
+	InitialDelay:  time.Millisecond,
+	MaxDelay:      10 * time.Millisecond,
+	BackoffFactor: 1.1,
+}
+
+func TestPollReturnsResultOnSuccess(t *testing.T) {
+	ctx := context.Background()
+
+	res, err := apiutils.Poll(ctx, testOpts, func(_ context.Context, p int) (int, error) {
+		return p * 2, nil
+	}, 21)
+
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if res != 42 {
+		t.Fatalf("expected 42, got %d", res)
+	}
+}
+
+func TestPollRetriesUntilSuccess(t *testing.T) {
+	ctx := context.Background()
+
+	calls := 0
+	res, err := apiutils.Poll(ctx, testOpts, func(_ context.Context, _ struct{}) (string, error) {
+		calls++
+		if calls < 3 {
+			return "", apiutils.ErrPollShouldRetry
+		}
+		return "done", nil
+	}, struct{}{})
+
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+
+	if res != "done" {
+		t.Fatalf("expected \"done\", got %q", res)
+	}
+
+	if calls != 3 {
+		t.Fatalf("expected 3 calls, got %d", calls)
+	}
+}
+
+func TestPollReturnsNonRetryableError(t *testing.T) {
+	ctx := context.Background()
+	sentinel := errors.New("boom")
+
+	_, err := apiutils.Poll(ctx, testOpts, func(_ context.Context, _ struct{}) (string, error) {
+		return "", sentinel
+	}, struct{}{})
+
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("expected sentinel error, got %v", err)
+	}
+}
+
+// TestPollDoesNotPanicWhenContextIsCancelledDuringCall reproduces the race
+// described in #448: the polling function is still running when the context is
+// cancelled, and returns a successful result afterwards.
+func TestPollDoesNotPanicWhenContextIsCancelledDuringCall(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	entered := make(chan struct{})
+	release := make(chan struct{})
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := apiutils.Poll(ctx, testOpts, func(_ context.Context, _ struct{}) (string, error) {
+			close(entered)
+			<-release
+			return "late result", nil
+		}, struct{}{})
+		done <- err
+	}()
+
+	<-entered
+	cancel()
+
+	// Give Poll a chance to observe the cancellation before the polling
+	// function returns its (now unwanted) result.
+	time.Sleep(50 * time.Millisecond)
+	close(release)
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("expected context.Canceled, got %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("Poll did not return after the context was cancelled")
+	}
+}
+
+// TestPollDoesNotLeakGoroutines covers the secondary issue in #448: a Poll call
+// that returns because its context expired used to leave a goroutine parked on
+// the ticker channel forever.
+func TestPollDoesNotLeakGoroutines(t *testing.T) {
+	before := runtime.NumGoroutine()
+
+	for range 20 {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Millisecond)
+		_, err := apiutils.Poll(ctx, testOpts, func(_ context.Context, _ struct{}) (string, error) {
+			return "", apiutils.ErrPollShouldRetry
+		}, struct{}{})
+		cancel()
+
+		if !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("expected context.DeadlineExceeded, got %v", err)
+		}
+	}
+
+	// Allow any goroutines that are legitimately winding down to exit.
+	for range 50 {
+		if runtime.NumGoroutine() <= before+2 {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	t.Fatalf("goroutine count grew from %d to %d", before, runtime.NumGoroutine())
+}


### PR DESCRIPTION
Fixes #448.

## Problem

`apiutils.Poll` ran the polling function in a goroutine that sent its outcome over two unbuffered channels, while the returning side closed those channels in a `defer`. If `Poll` returned via `<-ctx.Done()` and the polling function afterwards returned a success value or a non-retryable error, the goroutine sent on a closed channel — `panic: send on closed channel` on a goroutine with no recovery, which terminates the provider plugin. Terraform then reports a plugin crash instead of surfacing the timeout as a diagnostic.

The same `defer` called `Ticker.Stop()`, which does not close `t.C`, so a goroutine parked at `<-t.C` blocked forever: every cancelled `Poll` leaked one goroutine for the lifetime of the process.

## Change

The polling loop now runs inline in `Poll`, with a `select` on `ctx.Done()` and the ticker. Both channels and the second goroutine are gone, so neither failure mode is reachable.

Two behavioural notes:

- A context that is cancelled while the polling function is in flight now deterministically wins over that function's return value; `Poll` returns `ctx.Err()`.
- The previous `errors.Is(e, context.DeadlineExceeded)` branch returned from the goroutine without sending anything, leaving the caller blocked until the outer context was done. That error is now returned to the caller like any other non-retryable error.

Retry semantics (`ErrPollShouldRetry`, `ErrNotFound`, `ErrPermissionDenied`) and the backoff schedule are unchanged.

## Tests

`internal/apiutils/poll_test.go` is new and covers success, retry-until-success, non-retryable errors, the cancellation race, and goroutine accounting. Verified against the old implementation: `TestPollDoesNotPanicWhenContextIsCancelledDuringCall` panics with `send on closed channel` there, and passes here (`go test -race`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01588DUAd5rUUps9pejjtNLD