### PR TITLE
fix(container_stack): make timeouts configurable

### DIFF
--- a/docs/resources/container_stack.md
+++ b/docs/resources/container_stack.md
@@ -82,6 +82,15 @@ resource "mittwald_container_stack" "nginx" {
     cron     = "0 3 * * *"
     timezone = "Europe/Berlin"
   }
+
+  # Creating or updating a stack waits until all of its containers are running,
+  # which includes pulling their images. The timeouts below are upper bounds,
+  # not waiting times -- but if your images are large enough that pulling them
+  # regularly takes longer than the defaults, you can adjust them here.
+  timeouts {
+    create = "30m"
+    update = "30m"
+  }
 }
 
 resource "mittwald_virtualhost" "nginx" {
@@ -110,6 +119,7 @@ resource "mittwald_virtualhost" "nginx" {
 ### Optional
 
 - `default_stack` (Boolean) Set this flag to use the project's default stack. Otherwise, a new stack will be created.
+- `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 - `update_schedule` (Attributes) An optional schedule for automatically updating the container images in this stack. (see [below for nested schema](#nestedatt--update_schedule))
 - `volumes` (Attributes Map) A map of volumes that should be provisioned for this stack. (see [below for nested schema](#nestedatt--volumes))
 
@@ -184,6 +194,17 @@ Optional:
 
     Either this attribute, or `project_path` must be set.
 
+
+
+<a id="nestedblock--timeouts"></a>
+### Nested Schema for `timeouts`
+
+Optional:
+
+- `create` (String) Time to wait for the stack to be created. This includes waiting for all of this stack's containers to reach the `running` state, which requires their images to be pulled first; how long that takes depends entirely on the images in question. Defaults to 30 minutes; this is only an upper bound, and creation returns as soon as all containers are running.
+- `delete` (String) Time to wait for the stack to be deleted; defaults to 10 minutes.
+- `read` (String) Time to wait when reading the stack's current state. This is an upper bound for the (usually near-instant) API calls involved; defaults to 2 minutes.
+- `update` (String) Time to wait for an update of the stack to complete, including waiting for changed or recreated containers to reach the `running` state again. Defaults to 30 minutes; this is only an upper bound, and the update returns as soon as all containers are running.
 
 
 <a id="nestedatt--update_schedule"></a>

--- a/examples/resources/mittwald_container_stack/resource.tf
+++ b/examples/resources/mittwald_container_stack/resource.tf
@@ -58,6 +58,15 @@ resource "mittwald_container_stack" "nginx" {
     cron     = "0 3 * * *"
     timezone = "Europe/Berlin"
   }
+
+  # Creating or updating a stack waits until all of its containers are running,
+  # which includes pulling their images. The timeouts below are upper bounds,
+  # not waiting times -- but if your images are large enough that pulling them
+  # regularly takes longer than the defaults, you can adjust them here.
+  timeouts {
+    create = "30m"
+    update = "30m"
+  }
 }
 
 resource "mittwald_virtualhost" "nginx" {

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/terraform-plugin-docs v0.25.0
 	github.com/hashicorp/terraform-plugin-framework v1.19.0
+	github.com/hashicorp/terraform-plugin-framework-timeouts v0.7.0
 	github.com/hashicorp/terraform-plugin-go v0.31.0
 	github.com/hashicorp/terraform-plugin-log v0.10.0
 	github.com/hashicorp/terraform-plugin-testing v1.16.0
@@ -50,7 +51,6 @@ require (
 	github.com/hashicorp/logutils v1.0.0 // indirect
 	github.com/hashicorp/terraform-exec v0.25.1 // indirect
 	github.com/hashicorp/terraform-json v0.27.3-0.20260213134036-298b8f6b673a // indirect
-	github.com/hashicorp/terraform-plugin-framework-timeouts v0.7.0 // indirect
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.40.1 // indirect
 	github.com/hashicorp/terraform-registry-address v0.4.0 // indirect
 	github.com/hashicorp/terraform-svchost v0.2.1 // indirect

--- a/internal/provider/resource/containerstack/model.go
+++ b/internal/provider/resource/containerstack/model.go
@@ -1,16 +1,18 @@
 package containerstackresource
 
 import (
+	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
 
 type ContainerStackModel struct {
-	ID             types.String `tfsdk:"id"`
-	ProjectID      types.String `tfsdk:"project_id"`
-	DefaultStack   types.Bool   `tfsdk:"default_stack"`
-	Containers     types.Map    `tfsdk:"containers"`
-	Volumes        types.Map    `tfsdk:"volumes"`
-	UpdateSchedule types.Object `tfsdk:"update_schedule"`
+	ID             types.String   `tfsdk:"id"`
+	ProjectID      types.String   `tfsdk:"project_id"`
+	DefaultStack   types.Bool     `tfsdk:"default_stack"`
+	Containers     types.Map      `tfsdk:"containers"`
+	Volumes        types.Map      `tfsdk:"volumes"`
+	UpdateSchedule types.Object   `tfsdk:"update_schedule"`
+	Timeouts       timeouts.Value `tfsdk:"timeouts"`
 }
 
 type UpdateScheduleModel struct {

--- a/internal/provider/resource/containerstack/ready.go
+++ b/internal/provider/resource/containerstack/ready.go
@@ -1,0 +1,41 @@
+package containerstackresource
+
+import (
+	"context"
+	"errors"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/mittwald/terraform-provider-mittwald/internal/apiext"
+)
+
+// waitUntilStackIsReady waits for the given stack's containers to reach the
+// `running` state, until the given context is done.
+//
+// Running out of time is not treated as an error: at this point, the stack has
+// already been created (or updated), and a hard failure would abort the
+// operation before the state is written — leaving the stack untracked, or the
+// state describing containers that no longer match reality. Instead, a warning
+// is emitted, and the containers' actual state is picked up by the read that
+// follows.
+//
+// Containers that are in an error state, and any other API error, are still
+// reported as errors.
+func waitUntilStackIsReady(ctx context.Context, client apiext.ContainerClient, stackID string, containerNames []string, timeoutHint string, d *diag.Diagnostics) {
+	err := client.WaitUntilStackIsReady(ctx, stackID, containerNames)
+	if err == nil {
+		return
+	}
+
+	if errors.Is(err, context.DeadlineExceeded) {
+		d.AddWarning(
+			"Container stack did not become ready in time",
+			"Not all containers of stack "+stackID+" reached the `running` state in time. They may still be "+
+				"starting up; their current state will be picked up by the next `terraform plan` or "+
+				"`terraform apply`.\n\n"+timeoutHint,
+		)
+
+		return
+	}
+
+	d.AddError("API error while waiting for stack to be ready", err.Error())
+}

--- a/internal/provider/resource/containerstack/resource.go
+++ b/internal/provider/resource/containerstack/resource.go
@@ -3,6 +3,7 @@ package containerstackresource
 import (
 	"context"
 
+	"github.com/hashicorp/terraform-plugin-framework-timeouts/resource/timeouts"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/mapplanmodifier"
@@ -31,7 +32,7 @@ type Resource struct {
 func (r *Resource) Metadata(_ context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
 	resp.TypeName = req.ProviderTypeName + "_container_stack"
 }
-func (r *Resource) Schema(_ context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
+func (r *Resource) Schema(ctx context.Context, _ resource.SchemaRequest, resp *resource.SchemaResponse) {
 	builder := common.AttributeBuilderFor("container_stack")
 	resp.Schema = schema.Schema{
 		MarkdownDescription: "This resource models a container stack.\n\n" +
@@ -218,6 +219,26 @@ func (r *Resource) Schema(_ context.Context, _ resource.SchemaRequest, resp *res
 					},
 				},
 			},
+		},
+
+		Blocks: map[string]schema.Block{
+			"timeouts": timeouts.Block(ctx, timeouts.Opts{
+				Create: true,
+				CreateDescription: "Time to wait for the stack to be created. This includes waiting for all of " +
+					"this stack's containers to reach the `running` state, which requires their images to be " +
+					"pulled first; how long that takes depends entirely on the images in question. " +
+					"Defaults to 30 minutes; this is only an upper bound, and creation returns as soon as all " +
+					"containers are running.",
+				Read: true,
+				ReadDescription: "Time to wait when reading the stack's current state. This is an upper bound " +
+					"for the (usually near-instant) API calls involved; defaults to 2 minutes.",
+				Update: true,
+				UpdateDescription: "Time to wait for an update of the stack to complete, including waiting for " +
+					"changed or recreated containers to reach the `running` state again. Defaults to 30 minutes; " +
+					"this is only an upper bound, and the update returns as soon as all containers are running.",
+				Delete:            true,
+				DeleteDescription: "Time to wait for the stack to be deleted; defaults to 10 minutes.",
+			}),
 		},
 	}
 }

--- a/internal/provider/resource/containerstack/resource_create.go
+++ b/internal/provider/resource/containerstack/resource_create.go
@@ -2,6 +2,7 @@ package containerstackresource
 
 import (
 	"context"
+	"errors"
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -32,17 +33,36 @@ func (r *Resource) Create(ctx context.Context, req resource.CreateRequest, resp 
 		return
 	}
 
+	createTimeout, diags := data.Timeouts.Create(ctx, DefaultCreateTimeout)
+	resp.Diagnostics.Append(diags...)
+
+	readTimeout, diags := data.Timeouts.Read(ctx, DefaultReadTimeout)
+	resp.Diagnostics.Append(diags...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	createCtx, cancel := context.WithTimeout(ctx, createTimeout)
+	defer cancel()
+
 	if data.DefaultStack.ValueBool() {
-		r.createInDefaultStack(ctx, &data, resp)
+		r.createInDefaultStack(createCtx, &data, resp)
 	} else {
-		r.createAsNewStack(ctx, &data, resp)
+		r.createAsNewStack(createCtx, &data, resp)
 	}
 
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	resp.Diagnostics.Append(r.read(ctx, &data, &data)...)
+	// The read-back gets its own budget, so that an exhausted create timeout
+	// does not also fail the read; that would leave the state unwritten and the
+	// stack we just created untracked.
+	readCtx, cancel := context.WithTimeout(ctx, readTimeout)
+	defer cancel()
+
+	resp.Diagnostics.Append(r.read(readCtx, &data, &data)...)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
@@ -62,10 +82,9 @@ func (r *Resource) createAsNewStack(ctx context.Context, data *ContainerStackMod
 		return
 	}
 
-	providerutil.Try[any](&resp.Diagnostics, "API error while waiting for stack to be ready").
-		Do(client.WaitUntilStackIsReady(ctx, stack.Id, nil))
-
 	data.ID = types.StringValue(stack.Id)
+
+	waitUntilStackIsReady(ctx, client, stack.Id, nil, createTimeoutHint, &resp.Diagnostics)
 
 	if !data.UpdateSchedule.IsNull() && !data.UpdateSchedule.IsUnknown() {
 		r.reconcileUpdateSchedule(ctx, data, &resp.Diagnostics)
@@ -77,11 +96,18 @@ func (r *Resource) createInDefaultStack(ctx context.Context, data *ContainerStac
 
 	client := apiext.NewContainerClient(r.client)
 
-	stack := providerutil.
-		Try[*containerv2.StackResponse](&resp.Diagnostics, "failed to get default stack").
-		DoVal(client.PollDefaultStack(ctx, data.ProjectID.ValueString()))
+	stack, err := client.PollDefaultStack(ctx, data.ProjectID.ValueString())
+	if err != nil {
+		if errors.Is(err, context.DeadlineExceeded) {
+			resp.Diagnostics.AddError(
+				"failed to get default stack",
+				"the default stack of project "+data.ProjectID.ValueString()+" did not become available in time. "+
+					createTimeoutHint,
+			)
+		} else {
+			resp.Diagnostics.AddError("failed to get default stack", err.Error())
+		}
 
-	if resp.Diagnostics.HasError() {
 		return
 	}
 
@@ -100,8 +126,13 @@ func (r *Resource) createInDefaultStack(ctx context.Context, data *ContainerStac
 		Try[*containerv2.StackResponse](&resp.Diagnostics, "API error while declaring stack").
 		DoValResp(client.UpdateStack(ctx, *updateRequest))
 
-	providerutil.Try[any](&resp.Diagnostics, "API error while waiting for stack to be ready").
-		Do(client.WaitUntilStackIsReady(ctx, stack.Id, data.ContainerNames()))
+	// Without this, a failed update would still spend the entire create budget
+	// waiting for containers that were never asked to change.
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	waitUntilStackIsReady(ctx, client, stack.Id, data.ContainerNames(), createTimeoutHint, &resp.Diagnostics)
 
 	if !data.UpdateSchedule.IsNull() && !data.UpdateSchedule.IsUnknown() {
 		r.reconcileUpdateSchedule(ctx, data, &resp.Diagnostics)

--- a/internal/provider/resource/containerstack/resource_delete.go
+++ b/internal/provider/resource/containerstack/resource_delete.go
@@ -2,6 +2,7 @@ package containerstackresource
 
 import (
 	"context"
+
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/mittwald/api-client-go/mittwaldv2/generated/schemas/containerv2"
 	"github.com/mittwald/terraform-provider-mittwald/internal/provider/providerutil"
@@ -27,6 +28,16 @@ func (r *Resource) Delete(ctx context.Context, req resource.DeleteRequest, resp 
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	deleteTimeout, diags := stateData.Timeouts.Delete(ctx, DefaultDeleteTimeout)
+	resp.Diagnostics.Append(diags...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, deleteTimeout)
+	defer cancel()
 
 	// The "default" stack has a special role, and we will not delete it even if
 	// the user requests it. Instead, we will simply purge all containers and volumes

--- a/internal/provider/resource/containerstack/resource_read.go
+++ b/internal/provider/resource/containerstack/resource_read.go
@@ -2,12 +2,11 @@ package containerstackresource
 
 import (
 	"context"
+	"errors"
 
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/mittwald/api-client-go/mittwaldv2/generated/clients/containerclientv2"
-	"github.com/mittwald/api-client-go/mittwaldv2/generated/schemas/containerv2"
-	"github.com/mittwald/terraform-provider-mittwald/internal/provider/providerutil"
 )
 
 // Read updates the state with the latest data from the API.
@@ -19,16 +18,32 @@ func (r *Resource) Read(ctx context.Context, req resource.ReadRequest, resp *res
 		return
 	}
 
-	resp.Diagnostics.Append(r.read(ctx, &data, &data)...)
+	readTimeout, diags := data.Timeouts.Read(ctx, DefaultReadTimeout)
+	resp.Diagnostics.Append(diags...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	readCtx, cancel := context.WithTimeout(ctx, readTimeout)
+	defer cancel()
+
+	resp.Diagnostics.Append(r.read(readCtx, &data, &data)...)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
 func (r *Resource) read(ctx context.Context, state, plan *ContainerStackModel) (res diag.Diagnostics) {
-	stack := providerutil.
-		Try[*containerv2.StackResponse](&res, "API error while fetching stack").
-		DoValResp(r.client.Container().GetStack(ctx, containerclientv2.GetStackRequest{StackID: state.ID.ValueString()}))
+	stack, _, err := r.client.Container().GetStack(ctx, containerclientv2.GetStackRequest{StackID: state.ID.ValueString()})
+	if err != nil {
+		if errors.Is(err, context.DeadlineExceeded) {
+			res.AddError(
+				"API error while fetching stack",
+				"the stack "+state.ID.ValueString()+" could not be read in time. "+readTimeoutHint,
+			)
+		} else {
+			res.AddError("API error while fetching stack", err.Error())
+		}
 
-	if res.HasError() {
 		return
 	}
 

--- a/internal/provider/resource/containerstack/resource_update.go
+++ b/internal/provider/resource/containerstack/resource_update.go
@@ -29,51 +29,76 @@ func (r *Resource) Update(ctx context.Context, req resource.UpdateRequest, resp 
 		return
 	}
 
+	updateTimeout, diags := planData.Timeouts.Update(ctx, DefaultUpdateTimeout)
+	resp.Diagnostics.Append(diags...)
+
+	readTimeout, diags := planData.Timeouts.Read(ctx, DefaultReadTimeout)
+	resp.Diagnostics.Append(diags...)
+
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// The timeouts block is part of the configuration, not of the remote object;
+	// carry the planned value over, or Terraform will complain about a changed
+	// value once the state below is written from stateData.
+	stateData.Timeouts = planData.Timeouts
+
 	ctx = tflog.SetField(ctx, "stack_id", stateData.ID.ValueString())
 	client := apiext.NewContainerClient(r.client)
+
+	updateCtx, cancel := context.WithTimeout(ctx, updateTimeout)
+	defer cancel()
 
 	var stack *containerv2.StackResponse
 
 	if stateData.DefaultStack.ValueBool() {
-		req := planData.ToUpdateRequest(ctx, &stateData, &resp.Diagnostics)
+		req := planData.ToUpdateRequest(updateCtx, &stateData, &resp.Diagnostics)
 		if resp.Diagnostics.HasError() || req == nil {
 			return
 		}
 
 		stack = providerutil.
 			Try[*containerv2.StackResponse](&resp.Diagnostics, "API error while updating stack").
-			DoValResp(client.UpdateStack(ctx, *req))
+			DoValResp(client.UpdateStack(updateCtx, *req))
 	} else {
-		req := planData.ToDeclareRequest(ctx, &resp.Diagnostics)
+		req := planData.ToDeclareRequest(updateCtx, &resp.Diagnostics)
 		if resp.Diagnostics.HasError() || req == nil {
 			return
 		}
 
 		stack = providerutil.
 			Try[*containerv2.StackResponse](&resp.Diagnostics, "API error while declaring stack").
-			DoValResp(client.DeclareStack(ctx, *req))
+			DoValResp(client.DeclareStack(updateCtx, *req))
 	}
 
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	r.recreateContainers(ctx, planData, stack, resp)
+	r.recreateContainers(updateCtx, planData, stack, resp)
 	if resp.Diagnostics.HasError() {
 		return
 	}
 
-	providerutil.Try[any](&resp.Diagnostics, "API error while waiting for stack to be ready").
-		Do(client.WaitUntilStackIsReady(ctx, stack.Id, planData.ContainerNames()))
+	waitUntilStackIsReady(updateCtx, client, stack.Id, planData.ContainerNames(), updateTimeoutHint, &resp.Diagnostics)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
 	// Only reconcile when the schedule actually changed. An unknown planned
 	// value is not a meaningful change (it gets resolved during apply), and must
 	// not be treated as a removal, which would unset an existing schedule.
 	if !planData.UpdateSchedule.IsUnknown() && !planData.UpdateSchedule.Equal(stateData.UpdateSchedule) {
-		r.reconcileUpdateSchedule(ctx, &planData, &resp.Diagnostics)
+		r.reconcileUpdateSchedule(updateCtx, &planData, &resp.Diagnostics)
 	}
 
-	resp.Diagnostics.Append(r.read(ctx, &stateData, &planData)...)
+	// Like on create, the read-back gets its own budget, so that an exhausted
+	// update timeout does not also fail the read and leave a stale state behind.
+	readCtx, cancel := context.WithTimeout(ctx, readTimeout)
+	defer cancel()
+
+	resp.Diagnostics.Append(r.read(readCtx, &stateData, &planData)...)
 	resp.Diagnostics.Append(resp.State.Set(ctx, &stateData)...)
 }
 

--- a/internal/provider/resource/containerstack/schema_test.go
+++ b/internal/provider/resource/containerstack/schema_test.go
@@ -1,0 +1,47 @@
+package containerstackresource_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	. "github.com/onsi/gomega"
+
+	containerstackresource "github.com/mittwald/terraform-provider-mittwald/internal/provider/resource/containerstack"
+)
+
+// TestResourceModelMatchesSchema asserts that the resource model (including the
+// timeouts block) can actually be filled from a state object built from the
+// resource schema.
+func TestResourceModelMatchesSchema(t *testing.T) {
+	g := NewWithT(t)
+	ctx := context.Background()
+
+	res := containerstackresource.New()
+
+	resp := resource.SchemaResponse{}
+	res.Schema(ctx, resource.SchemaRequest{}, &resp)
+
+	g.Expect(resp.Diagnostics.HasError()).To(BeFalse())
+
+	objectType, ok := resp.Schema.Type().TerraformType(ctx).(tftypes.Object)
+	g.Expect(ok).To(BeTrue())
+	attributes := make(map[string]tftypes.Value, len(objectType.AttributeTypes))
+
+	for name, attributeType := range objectType.AttributeTypes {
+		attributes[name] = tftypes.NewValue(attributeType, nil)
+	}
+
+	state := tfsdk.State{
+		Schema: resp.Schema,
+		Raw:    tftypes.NewValue(objectType, attributes),
+	}
+
+	var data containerstackresource.ContainerStackModel
+
+	g.Expect(state.Get(ctx, &data)).To(BeEmpty())
+	g.Expect(data.ID.IsNull()).To(BeTrue())
+	g.Expect(data.Timeouts.IsNull()).To(BeTrue())
+}

--- a/internal/provider/resource/containerstack/timeouts.go
+++ b/internal/provider/resource/containerstack/timeouts.go
@@ -1,0 +1,32 @@
+package containerstackresource
+
+import "time"
+
+const (
+	// DefaultCreateTimeout is the default timeout for creating a container
+	// stack. Most of it is spent waiting for the containers to actually reach
+	// the `running` state, which involves pulling the respective images; how
+	// long this takes depends entirely on the images in question.
+	DefaultCreateTimeout = 30 * time.Minute
+
+	// DefaultReadTimeout is the default timeout for reading a container stack.
+	// This is an upper bound for a handful of (usually near-instant) API calls.
+	DefaultReadTimeout = 2 * time.Minute
+
+	// DefaultUpdateTimeout is the default timeout for updating a container
+	// stack. Like DefaultCreateTimeout, most of it is spent waiting for
+	// (possibly recreated) containers to reach the `running` state again.
+	DefaultUpdateTimeout = 30 * time.Minute
+
+	// DefaultDeleteTimeout is the default timeout for deleting a container
+	// stack. No polling is involved here, so this is just an upper bound for a
+	// single API call.
+	DefaultDeleteTimeout = 10 * time.Minute
+
+	// createTimeoutHint, readTimeoutHint and updateTimeoutHint are appended to
+	// diagnostics that are caused by an exhausted timeout, to point users at the
+	// knob they can turn.
+	createTimeoutHint = "If this happens regularly, increase the `timeouts.create` value on this resource."
+	readTimeoutHint   = "If this happens regularly, increase the `timeouts.read` value on this resource."
+	updateTimeoutHint = "If this happens regularly, increase the `timeouts.update` value on this resource."
+)


### PR DESCRIPTION
Follow-up to #449, applying the same treatment to `mittwald_container_stack`.

## Problem

Creating or updating a container stack waits for its containers to reach the `running` state — which includes pulling their images — and, for the default stack, first polls until the stack itself shows up. Neither wait has a time budget of its own, and there is no way for users to bound or extend one.

On top of that, a failure while waiting aborts the operation before any state is written. After a create, that leaves the stack that was just created untracked by Terraform.

## Changes

- **Configurable timeouts.** The resource exposes a `timeouts` block via `terraform-plugin-framework-timeouts`, with `create` (**30m**), `read` (**2m**), `update` (**30m**) and `delete` (**10m**). Create and update are generous because the bulk of the time is spent pulling container images, which depends entirely on the images in question.
- **Graceful degradation.** Running out of time while waiting for readiness is no longer an error: `waitUntilStackIsReady` emits a warning that points at the relevant `timeouts` knob, so create still writes state and update still persists what it changed; the containers' actual state is picked up by the next read. Containers in an *error* state, and every other API error, are still reported as errors.
- **Separate budget for the read-back.** The `r.read` call at the end of create and update runs under the `read` timeout rather than the (possibly already exhausted) create/update one, so a slow provisioning run cannot also break the read that writes the state.
- **Timeout-specific diagnostics.** A default stack that does not appear in time, and a `GetStack` that does not answer in time, now say so and name the knob to turn, instead of surfacing a bare `context deadline exceeded`.
- Update carries the planned `timeouts` value into the state it writes, since the state is built from `stateData`.
- A failed `UpdateStack` in the default-stack create path now returns early instead of spending the whole create budget waiting for containers that were never asked to change.

A unit test asserts that the model still lines up with the schema, mirroring the one added for `mittwald_project`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)